### PR TITLE
RMET-539 Firebase Analytics Plugin - Fix the way we include Google Services for Android 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The changes documented here do not include those from the original repository.
 
 ## [Unreleased]
 
+## 2021-03-04
+- Fix: Changed the way we include Google Services for Android. (https://outsystemsrd.atlassian.net/browse/RMET-539)
+
 ## 2021-02-26
 - Fix: Fixed MABS builds for both versions of MABS and Sample App connecting to Firebase Project. (https://outsystemsrd.atlassian.net/browse/RMET-539)
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -66,10 +66,10 @@ xmlns:android="http://schemas.android.com/apk/res/android"
             </feature>
         </config-file>
 
-        <config-file target="config.xml" parent="/*">
+        <!--<config-file target="config.xml" parent="/*">
             <preference name="GradlePluginGoogleServicesEnabled" value="true" />
             <preference name="GradlePluginGoogleServicesVersion" value="4.3.3" />
-        </config-file>
+        </config-file>-->
 
         <config-file target="AndroidManifest.xml" parent="/*">
             <uses-permission android:name="android.permission.INTERNET" />
@@ -83,8 +83,10 @@ xmlns:android="http://schemas.android.com/apk/res/android"
         <dependency id="cordova-support-android-plugin" version="~1.0.0"/>
 
         <framework src="com.google.firebase:firebase-analytics:$ANDROID_FIREBASE_ANALYTICS_VERSION" />
+        <framework src="build.gradle" custom="true" type="gradleReference" />
 
         <resource-file src="google-services.json" target="./google-services.json" />
+
 
         <source-file src="src/android/FirebaseAnalyticsPlugin.java"
             target-dir="src/by/chemerisuk/cordova/firebase/" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -66,11 +66,6 @@ xmlns:android="http://schemas.android.com/apk/res/android"
             </feature>
         </config-file>
 
-        <!--<config-file target="config.xml" parent="/*">
-            <preference name="GradlePluginGoogleServicesEnabled" value="true" />
-            <preference name="GradlePluginGoogleServicesVersion" value="4.3.3" />
-        </config-file>-->
-
         <config-file target="AndroidManifest.xml" parent="/*">
             <uses-permission android:name="android.permission.INTERNET" />
         </config-file>


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Added gradle file to include GoogleServices in Android applications, instead of using a Preference like it was before.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->

MABS 6.3 cannot be used with the Preference option.

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

All MABS builds working and no crashes in the app. Plugin working for both platforms.

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
