### PR TITLE
RMET-547 Firebase Analytics Plugin - Fix configurations hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The changes documented here do not include those from the original repository.
 
 ## [Unreleased]
 
+## 2021-03-11
+- Fix: Fixed the configurations hook (unzipAndCopyConfigurations). (https://outsystemsrd.atlassian.net/browse/RMET-547)
+
 ## 2021-03-04
 - Fix: Changed the way we include Google Services for Android. (https://outsystemsrd.atlassian.net/browse/RMET-539)
 

--- a/hooks/configurations/unzipAndCopyConfigurations.js
+++ b/hooks/configurations/unzipAndCopyConfigurations.js
@@ -5,6 +5,8 @@ var AdmZip = require("adm-zip");
 
 var utils = require("./utilities");
 
+var utilsApp = require("../utilities");
+
 var constants = {
   googleServices: "google-services"
 };
@@ -53,13 +55,31 @@ module.exports = function(context) {
   var sourceFilePath = path.join(targetPath, fileName);
   var destFilePath = path.join(context.opts.plugin.dir, fileName);
 
-  utils.copyFromSourceToDestPath(defer, sourceFilePath, destFilePath);
+  var androidPath =  "platforms/android/app";
+  var iOSPath = "platforms/ios/" + utilsApp.getAppName(context) + "/Resources";
+
+  var completeFilePath;
+
+  var isAndroid = platform.localeCompare("android");
+  var isIOS = platform.localeCompare("ios");
+
+  if(isAndroid == 0){ //android code
+    completeFilePath = path.join(context.opts.projectRoot, androidPath);
+  }
+  else if(isIOS == 0){ //iOS code
+    completeFilePath = path.join(context.opts.projectRoot, iOSPath);
+  }
+
+  if(!utils.checkIfFolderExists(destFilePath)){
+    utils.copyFromSourceToDestPath(defer, sourceFilePath, destFilePath);
+  }
 
   if (cordovaAbove7) {
-    var destPath = path.join(context.opts.projectRoot, "platforms", platform, "app");
-    if (utils.checkIfFolderExists(destPath)) {
-      var destFilePath = path.join(destPath, fileName);
-      utils.copyFromSourceToDestPath(defer, sourceFilePath, destFilePath);
+    if (utils.checkIfFolderExists(completeFilePath)) {
+      var destFilePath = path.join(completeFilePath, fileName);
+      if(!utils.checkIfFolderExists(destFilePath)){
+        utils.copyFromSourceToDestPath(defer, sourceFilePath, destFilePath);
+      }
     }
   }
       

--- a/plugin.xml
+++ b/plugin.xml
@@ -47,6 +47,8 @@ xmlns:android="http://schemas.android.com/apk/res/android"
             <string>$AUTOMATIC_SCREEN_REPORTING_ENABLED</string>
         </config-file>
 
+        <resource-file src="GoogleService-Info.plist" target="./GoogleService-Info.plist" />
+
         <header-file src="src/ios/FirebaseAnalyticsPlugin.h" />
         <source-file src="src/ios/FirebaseAnalyticsPlugin.m" />
 
@@ -74,6 +76,8 @@ xmlns:android="http://schemas.android.com/apk/res/android"
         </config-file>
 
         <dependency id="cordova-support-android-plugin" version="~1.0.0"/>
+
+         <resource-file src="google-services.json" target="./google-services.json" />
 
         <framework src="com.google.firebase:firebase-analytics:$ANDROID_FIREBASE_ANALYTICS_VERSION" />
         <framework src="build.gradle" custom="true" type="gradleReference" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -47,8 +47,6 @@ xmlns:android="http://schemas.android.com/apk/res/android"
             <string>$AUTOMATIC_SCREEN_REPORTING_ENABLED</string>
         </config-file>
 
-        <resource-file src="GoogleService-Info.plist" target="./GoogleService-Info.plist" />
-
         <header-file src="src/ios/FirebaseAnalyticsPlugin.h" />
         <source-file src="src/ios/FirebaseAnalyticsPlugin.m" />
 
@@ -79,9 +77,6 @@ xmlns:android="http://schemas.android.com/apk/res/android"
 
         <framework src="com.google.firebase:firebase-analytics:$ANDROID_FIREBASE_ANALYTICS_VERSION" />
         <framework src="build.gradle" custom="true" type="gradleReference" />
-
-        <resource-file src="google-services.json" target="./google-services.json" />
-
 
         <source-file src="src/android/FirebaseAnalyticsPlugin.java"
             target-dir="src/by/chemerisuk/cordova/firebase/" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -47,8 +47,6 @@ xmlns:android="http://schemas.android.com/apk/res/android"
             <string>$AUTOMATIC_SCREEN_REPORTING_ENABLED</string>
         </config-file>
 
-        <resource-file src="GoogleService-Info.plist" target="./GoogleService-Info.plist" />
-
         <header-file src="src/ios/FirebaseAnalyticsPlugin.h" />
         <source-file src="src/ios/FirebaseAnalyticsPlugin.m" />
 
@@ -76,8 +74,6 @@ xmlns:android="http://schemas.android.com/apk/res/android"
         </config-file>
 
         <dependency id="cordova-support-android-plugin" version="~1.0.0"/>
-
-         <resource-file src="google-services.json" target="./google-services.json" />
 
         <framework src="com.google.firebase:firebase-analytics:$ANDROID_FIREBASE_ANALYTICS_VERSION" />
         <framework src="build.gradle" custom="true" type="gradleReference" />


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Fixes the way we copy the firebase configuration files, because the iOS file path was wrong. Also we need to check if the file already exists before copying.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->
The hook did not use the correct file path for iOS and did not check if the files already exist before copying.

References: https://outsystemsrd.atlassian.net/browse/RMET-547 

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [x] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

MABS builds all working and analytics data being logged for both Android and iOS.

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
