### PR TITLE
RMET-580 Firebase Analytics Plugin - Fix Android Google Services build error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The changes documented here do not include those from the original repository.
 
 ## [Unreleased]
 
+## 2021-04-08
+- Fix: Fixed Android MABS builds for Firebase Analytics being used with OneSignal (https://outsystemsrd.atlassian.net/browse/RMET-580)
+
 ## 2021-03-29
 - Fix: Fixed hook unzipAndCopyConfigurations
 

--- a/build.gradle
+++ b/build.gradle
@@ -20,5 +20,6 @@ ext.postBuildExtras = {
         // apply plugin: 'com.google.gms.google-services'
         // class must be used instead of id(string) to be able to apply plugin from non-root gradle file
         apply plugin: com.google.gms.googleservices.GoogleServicesPlugin
+        googleServices.disableVersionCheck = true
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,6 @@ ext.postBuildExtras = {
     if (project.extensions.findByName('googleServices') == null) {
         // apply plugin: 'com.google.gms.google-services'
         // class must be used instead of id(string) to be able to apply plugin from non-root gradle file
-        apply plugin: com.google.gms.googleservices.GoogleServicesPlugin
+        //apply plugin: com.google.gms.googleservices.GoogleServicesPlugin
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,6 @@ ext.postBuildExtras = {
     if (project.extensions.findByName('googleServices') == null) {
         // apply plugin: 'com.google.gms.google-services'
         // class must be used instead of id(string) to be able to apply plugin from non-root gradle file
-        //apply plugin: com.google.gms.googleservices.GoogleServicesPlugin
+        apply plugin: com.google.gms.googleservices.GoogleServicesPlugin
     }
 }

--- a/plugin.xml
+++ b/plugin.xml
@@ -75,17 +75,12 @@ xmlns:android="http://schemas.android.com/apk/res/android"
             <meta-data android:name="google_analytics_automatic_screen_reporting_enabled" android:value="$AUTOMATIC_SCREEN_REPORTING_ENABLED" />
         </config-file>
 
-        <config-file target="config.xml" parent="/*">
-            <preference name="GradlePluginGoogleServicesEnabled" value="true" />
-            <preference name="GradlePluginGoogleServicesVersion" value="4.3.+" />
-        </config-file>
-
         <dependency id="cordova-support-android-plugin" version="~1.0.0"/>
 
          <resource-file src="google-services.json" target="./google-services.json" />
 
         <framework src="com.google.firebase:firebase-analytics:$ANDROID_FIREBASE_ANALYTICS_VERSION" />
-        <!--<framework src="build.gradle" custom="true" type="gradleReference" />-->
+        <framework src="build.gradle" custom="true" type="gradleReference" />
 
         <source-file src="src/android/FirebaseAnalyticsPlugin.java"
             target-dir="src/by/chemerisuk/cordova/firebase/" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -57,7 +57,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
     </platform>
 
     <platform name="android">
-        <preference name="ANDROID_FIREBASE_ANALYTICS_VERSION" default="17.6.+"/>
+        <preference name="ANDROID_FIREBASE_ANALYTICS_VERSION" default="17.0.+"/>
 
         <config-file target="res/xml/config.xml" parent="/*">
             <feature name="FirebaseAnalytics">

--- a/plugin.xml
+++ b/plugin.xml
@@ -57,7 +57,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
     </platform>
 
     <platform name="android">
-        <preference name="ANDROID_FIREBASE_ANALYTICS_VERSION" default="18.0.+"/>
+        <preference name="ANDROID_FIREBASE_ANALYTICS_VERSION" default="17.6.+"/>
 
         <config-file target="res/xml/config.xml" parent="/*">
             <feature name="FirebaseAnalytics">

--- a/plugin.xml
+++ b/plugin.xml
@@ -75,12 +75,17 @@ xmlns:android="http://schemas.android.com/apk/res/android"
             <meta-data android:name="google_analytics_automatic_screen_reporting_enabled" android:value="$AUTOMATIC_SCREEN_REPORTING_ENABLED" />
         </config-file>
 
+        <config-file target="config.xml" parent="/*">
+            <preference name="GradlePluginGoogleServicesEnabled" value="true" />
+            <preference name="GradlePluginGoogleServicesVersion" value="4.3.+" />
+        </config-file>
+
         <dependency id="cordova-support-android-plugin" version="~1.0.0"/>
 
          <resource-file src="google-services.json" target="./google-services.json" />
 
         <framework src="com.google.firebase:firebase-analytics:$ANDROID_FIREBASE_ANALYTICS_VERSION" />
-        <framework src="build.gradle" custom="true" type="gradleReference" />
+        <!--<framework src="build.gradle" custom="true" type="gradleReference" />-->
 
         <source-file src="src/android/FirebaseAnalyticsPlugin.java"
             target-dir="src/by/chemerisuk/cordova/firebase/" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -57,7 +57,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
     </platform>
 
     <platform name="android">
-        <preference name="ANDROID_FIREBASE_ANALYTICS_VERSION" default="17.0.+"/>
+        <preference name="ANDROID_FIREBASE_ANALYTICS_VERSION" default="16.5.+"/>
 
         <config-file target="res/xml/config.xml" parent="/*">
             <feature name="FirebaseAnalytics">

--- a/plugin.xml
+++ b/plugin.xml
@@ -57,7 +57,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
     </platform>
 
     <platform name="android">
-        <preference name="ANDROID_FIREBASE_ANALYTICS_VERSION" default="16.0.+"/>
+        <preference name="ANDROID_FIREBASE_ANALYTICS_VERSION" default="18.0.+"/>
 
         <config-file target="res/xml/config.xml" parent="/*">
             <feature name="FirebaseAnalytics">

--- a/plugin.xml
+++ b/plugin.xml
@@ -57,7 +57,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
     </platform>
 
     <platform name="android">
-        <preference name="ANDROID_FIREBASE_ANALYTICS_VERSION" default="16.5.+"/>
+        <preference name="ANDROID_FIREBASE_ANALYTICS_VERSION" default="16.0.+"/>
 
         <config-file target="res/xml/config.xml" parent="/*">
             <feature name="FirebaseAnalytics">


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Used flag in build.gradle to disable version checking for google services.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->

We were having a build error for Android when building an app with Firebase Analytics and OneSignal because the two plugins have different versions of google services. So we disabled version checking for google-services and the build works. The plugins are also working fine. 

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

All MABS builds working and plugins working as well.

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
