### PR TITLE
RMET-732 Added App Tracking Transparency popups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The changes documented here do not include those from the original repository.
 
 ## [Unreleased]
 
+## 2021-08-16
+- Added App Tracking Transparency popups (https://outsystemsrd.atlassian.net/browse/RMET-732)
+
 ## 2021-07-22
 - Added Firebase Core Dependency to install config files (https://outsystemsrd.atlassian.net/browse/RMET-695)
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -45,9 +45,16 @@ xmlns:android="http://schemas.android.com/apk/res/android"
         <config-file target="*-Info.plist" parent="FirebaseAutomaticScreenReportingEnabled">
             <string>$AUTOMATIC_SCREEN_REPORTING_ENABLED</string>
         </config-file>
+        <config-file target="*-Info.plist" parent="NSUserTrackingUsageDescription">
+            <string>$(PRODUCT_NAME) wants to access your information</string>
+        </config-file>
+
+
 
         <header-file src="src/ios/FirebaseAnalyticsPlugin.h" />
         <source-file src="src/ios/FirebaseAnalyticsPlugin.m" />
+
+
 
         <framework src="Firebase/Analytics" type="podspec" spec="~> 7.0.0"/>
 

--- a/src/android/FirebaseAnalyticsPlugin.java
+++ b/src/android/FirebaseAnalyticsPlugin.java
@@ -81,6 +81,12 @@ public class FirebaseAnalyticsPlugin extends ReflectiveCordovaPlugin {
         callbackContext.success();
     }
 
+    @CordovaMethod
+    private void requestTrackingAuthorization(JSONObject params, CallbackContext callbackContext) throws JSONException {
+        //Does nothing. This is an iOS specific method.
+        callbackContext.success();
+    }
+
     private static Bundle parse(JSONObject params) throws JSONException {
         Bundle bundle = new Bundle();
         Iterator<String> it = params.keys();

--- a/src/ios/FirebaseAnalyticsPlugin.h
+++ b/src/ios/FirebaseAnalyticsPlugin.h
@@ -9,5 +9,6 @@
 - (void)setCurrentScreen:(CDVInvokedUrlCommand*)command;
 - (void)resetAnalyticsData:(CDVInvokedUrlCommand*)command;
 - (void)setDefaultEventParameters:(CDVInvokedUrlCommand*)command;
+- (void)requestTrackingAuthorization:(CDVInvokedUrlCommand*)command;
 
 @end

--- a/src/ios/FirebaseAnalyticsPlugin.m
+++ b/src/ios/FirebaseAnalyticsPlugin.m
@@ -78,4 +78,22 @@
     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
 
+
+typedef void (^ showPermissionInformationPopupHandler)(UIAlertAction*);
+- (void)showPermissionInformationPopup:(showPermissionInformationPopupHandler)confirmationHandler {
+    
+    UIAlertController *alert = [UIAlertController
+                                alertControllerWithTitle:@"Title"
+                                message:@"text mssg"
+                                preferredStyle:UIAlertControllerStyleAlert];
+    
+    UIAlertAction *okAction = [UIAlertAction
+                               actionWithTitle:@"Ok"
+                               style:UIAlertActionStyleDefault
+                               handler:confirmationHandler];
+    
+    [alert addAction:okAction];
+    [self.viewController presentViewController:alert animated:YES completion:nil];
+}
+
 @end

--- a/src/ios/FirebaseAnalyticsPlugin.m
+++ b/src/ios/FirebaseAnalyticsPlugin.m
@@ -78,40 +78,46 @@
     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
 
-- (void)requestTrackingAuthorization {
+- (void)requestTrackingAuthorization:(CDVInvokedUrlCommand *)command {
     
     if (@available(iOS 14, *)) {
-        
-        if(ATTrackingManager.trackingAuthorizationStatus == ATTrackingManagerAuthorizationStatusNotDetermined) {
-            
-            [ATTrackingManager requestTrackingAuthorizationWithCompletionHandler:^(ATTrackingManagerAuthorizationStatus status) {
-                switch(status) {
-                    case ATTrackingManagerAuthorizationStatusAuthorized:
-                        break;
-                        
-                    default:
-                        break;
+        [ATTrackingManager requestTrackingAuthorizationWithCompletionHandler:^(ATTrackingManagerAuthorizationStatus status) {
+            BOOL result = false;
+            switch(status) {
+                case ATTrackingManagerAuthorizationStatusAuthorized: {
+                    result = true;
+                    break;
                 }
-            }];
-            
-        }
-        
+                default: {
+                    result = false;
+                    break;
+                }
+            }
+            CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsBool:result];
+            [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+        }];
     }
     else {
-        // Fallback on earlier versions
+        CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsBool:true];
+        [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
     }
 }
 
 typedef void (^showPermissionInformationPopupHandler)(UIAlertAction*);
-- (void)showPermissionInformationPopup:(showPermissionInformationPopupHandler)confirmationHandler {
+- (void)showPermissionInformationPopup:
+(NSString *)title :
+(NSString *)message :
+(NSString *)actionText :
+(showPermissionInformationPopupHandler)confirmationHandler
+{
     
     UIAlertController *alert = [UIAlertController
-                                alertControllerWithTitle:@"Title"
-                                message:@"text mssg"
+                                alertControllerWithTitle:title
+                                message:message
                                 preferredStyle:UIAlertControllerStyleAlert];
     
     UIAlertAction *okAction = [UIAlertAction
-                               actionWithTitle:@"Ok"
+                               actionWithTitle:actionText
                                style:UIAlertActionStyleDefault
                                handler:confirmationHandler];
     

--- a/src/ios/FirebaseAnalyticsPlugin.m
+++ b/src/ios/FirebaseAnalyticsPlugin.m
@@ -1,7 +1,7 @@
 #import "FirebaseAnalyticsPlugin.h"
 
 @import Firebase;
-
+@import AppTrackingTransparency;
 
 @implementation FirebaseAnalyticsPlugin
 
@@ -78,8 +78,31 @@
     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
 
+- (void)requestTrackingAuthorization {
+    
+    if (@available(iOS 14, *)) {
+        
+        if(ATTrackingManager.trackingAuthorizationStatus == ATTrackingManagerAuthorizationStatusNotDetermined) {
+            
+            [ATTrackingManager requestTrackingAuthorizationWithCompletionHandler:^(ATTrackingManagerAuthorizationStatus status) {
+                switch(status) {
+                    case ATTrackingManagerAuthorizationStatusAuthorized:
+                        break;
+                        
+                    default:
+                        break;
+                }
+            }];
+            
+        }
+        
+    }
+    else {
+        // Fallback on earlier versions
+    }
+}
 
-typedef void (^ showPermissionInformationPopupHandler)(UIAlertAction*);
+typedef void (^showPermissionInformationPopupHandler)(UIAlertAction*);
 - (void)showPermissionInformationPopup:(showPermissionInformationPopupHandler)confirmationHandler {
     
     UIAlertController *alert = [UIAlertController
@@ -95,5 +118,7 @@ typedef void (^ showPermissionInformationPopupHandler)(UIAlertAction*);
     [alert addAction:okAction];
     [self.viewController presentViewController:alert animated:YES completion:nil];
 }
+
+
 
 @end

--- a/src/ios/FirebaseAnalyticsPlugin.m
+++ b/src/ios/FirebaseAnalyticsPlugin.m
@@ -80,6 +80,26 @@
 
 - (void)requestTrackingAuthorization:(CDVInvokedUrlCommand *)command {
     
+    bool showInformation = [[command.arguments objectAtIndex:0] boolValue];
+
+    if(showInformation) {
+        
+        NSString* title = [command.arguments objectAtIndex:1];
+        NSString* message = [command.arguments objectAtIndex:2];
+        NSString* buttonTitle = [command.arguments objectAtIndex:3];
+        
+        [self showPermissionInformationPopup:title :message :buttonTitle :^(UIAlertAction *action ) {
+            [self showTrackingAuthorizationPopup:command];
+        }];
+        
+    }
+    else {
+        [self showTrackingAuthorizationPopup:command];
+    }
+}
+
+- (void)showTrackingAuthorizationPopup:(CDVInvokedUrlCommand *)command {
+    
     if (@available(iOS 14, *)) {
         [ATTrackingManager requestTrackingAuthorizationWithCompletionHandler:^(ATTrackingManagerAuthorizationStatus status) {
             BOOL result = false;
@@ -107,7 +127,7 @@ typedef void (^showPermissionInformationPopupHandler)(UIAlertAction*);
 - (void)showPermissionInformationPopup:
 (NSString *)title :
 (NSString *)message :
-(NSString *)actionText :
+(NSString *)buttonTitle :
 (showPermissionInformationPopupHandler)confirmationHandler
 {
     
@@ -117,7 +137,7 @@ typedef void (^showPermissionInformationPopupHandler)(UIAlertAction*);
                                 preferredStyle:UIAlertControllerStyleAlert];
     
     UIAlertAction *okAction = [UIAlertAction
-                               actionWithTitle:actionText
+                               actionWithTitle:buttonTitle
                                style:UIAlertActionStyleDefault
                                handler:confirmationHandler];
     

--- a/www/FirebaseAnalytics.js
+++ b/www/FirebaseAnalytics.js
@@ -49,9 +49,25 @@ module.exports = {
             exec(resolve, reject, PLUGIN_NAME, "setDefaultEventParameters", [defaults || {}]);
         });
     },
-    requestTrackingAuthorization: function() {
+    requestTrackingAuthorization: function(showInformation, title, message, buttonTitle) {
         return new Promise(function(resolve, reject) {
-            exec(resolve, reject, PLUGIN_NAME, "requestTrackingAuthorization");
+
+            if(showInformation) {
+                if (typeof title !== "string") {
+                    return reject(new TypeError("Title property name must be a string"));
+                }
+    
+                if (typeof message !== "string") {
+                    return reject(new TypeError("Message property value must be a string"));
+                }
+    
+                if (typeof buttonTitle !== "string") {
+                    return reject(new TypeError("Button title property value must be a string"));
+                }
+            }
+
+
+            exec(resolve, reject, PLUGIN_NAME, "requestTrackingAuthorization", [showInformation, title, message, buttonTitle]);
         });
     }
 };

--- a/www/FirebaseAnalytics.js
+++ b/www/FirebaseAnalytics.js
@@ -48,5 +48,10 @@ module.exports = {
 
             exec(resolve, reject, PLUGIN_NAME, "setDefaultEventParameters", [defaults || {}]);
         });
+    },
+    requestTrackingAuthorization: function() {
+        return new Promise(function(resolve, reject) {
+            exec(resolve, reject, PLUGIN_NAME, "requestTrackingAuthorization");
+        });
     }
 };


### PR DESCRIPTION
## Description
- Created a new Cordova method that prompts an information alert and an authorization request for tracking information. The information alert is optional and should appear when the corresponding flag is set to "true". If set to "true", developers must also provide the text to be displayed on the alert.
- Created an iOS method that shows an alert with the provided text;
- Created an Android method that simply returns success upon being called;

## Context
There is a new requirement where the apps must be compliant when submitting an application to the Apple Store.
https://outsystemsrd.atlassian.net/browse/RMET-732
However, as to provide more information to the final user, it is recommended that developers implement an adicional popup that provides more information about the information that is being collected.

## Type of changes
- [ ] Fix (non-breaking change which fixes an issue)
- [X] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [X] iOS
- [X] JavaScript

## Tests
- Tested iOS and Android on our FirebaseSampleApp from MABS. Force removing and adding the modified plugin code.
- Tested iOS and Android on MABS 7.1.

## Checklist
- [X] Pull request title follows the format `RNMT-XXXX <title>`
- [X] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [x] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
