### PR TITLE
RMET-732 Updated Analytics plugin version on Android and iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The changes documented here do not include those from the original repository.
 
 ## [Unreleased]
 
+## 2021-08-24
+- Updated Firebase plugin versions to 8.6.0 on iOS and 19.0.+ on Android [RMET-732](https://outsystemsrd.atlassian.net/browse/RMET-732)
+
 ## 2021-08-16
 - Added App Tracking Transparency popups (https://outsystemsrd.atlassian.net/browse/RMET-732)
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -26,7 +26,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
     <dependency id="cordova-outsystems-firebase-core" url="https://github.com/OutSystems/cordova-outsystems-firebase-core.git#1.0.0"/>
 
     <platform name="ios">
-        <preference name="IOS_FIREBASE_ANALYTICS_VERSION" default="~> 7.0.0"/>
+        <preference name="IOS_FIREBASE_ANALYTICS_VERSION" default="~> 8.6.0"/>
 
         <config-file target="config.xml" parent="/*">
             <feature name="FirebaseAnalytics">
@@ -46,11 +46,19 @@ xmlns:android="http://schemas.android.com/apk/res/android"
             <string>$AUTOMATIC_SCREEN_REPORTING_ENABLED</string>
         </config-file>
         <config-file target="*-Info.plist" parent="NSUserTrackingUsageDescription">
-            <string>$(PRODUCT_NAME) wants to access your information</string>
+            <string>$(PRODUCT_NAME) needs your attention.</string>
         </config-file>
 
         <header-file src="src/ios/FirebaseAnalyticsPlugin.h" />
         <source-file src="src/ios/FirebaseAnalyticsPlugin.m" />
+
+        <!--
+        <podspec>
+            <pods >
+                <pod name="Firebase/Analytics" spec="~> 7.0.0"/>
+            </pods>
+        </podspec>
+        -->
 
         <framework src="Firebase/Analytics" type="podspec" spec="~> 8.6.0"/>
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -49,19 +49,15 @@ xmlns:android="http://schemas.android.com/apk/res/android"
             <string>$(PRODUCT_NAME) wants to access your information</string>
         </config-file>
 
-
-
         <header-file src="src/ios/FirebaseAnalyticsPlugin.h" />
         <source-file src="src/ios/FirebaseAnalyticsPlugin.m" />
 
-
-
-        <framework src="Firebase/Analytics" type="podspec" spec="~> 7.0.0"/>
+        <framework src="Firebase/Analytics" type="podspec" spec="~> 8.6.0"/>
 
     </platform>
 
     <platform name="android">
-        <preference name="ANDROID_FIREBASE_ANALYTICS_VERSION" default="18.0.+"/>
+        <preference name="ANDROID_FIREBASE_ANALYTICS_VERSION" default="19.0.+"/>
 
         <config-file target="res/xml/config.xml" parent="/*">
             <feature name="FirebaseAnalytics">

--- a/plugin.xml
+++ b/plugin.xml
@@ -52,15 +52,11 @@ xmlns:android="http://schemas.android.com/apk/res/android"
         <header-file src="src/ios/FirebaseAnalyticsPlugin.h" />
         <source-file src="src/ios/FirebaseAnalyticsPlugin.m" />
 
-        <!--
         <podspec>
             <pods >
-                <pod name="Firebase/Analytics" spec="~> 7.0.0"/>
+                <pod name="Firebase/Analytics" spec="~> 8.6.0"/>
             </pods>
         </podspec>
-        -->
-
-        <framework src="Firebase/Analytics" type="podspec" spec="~> 8.6.0"/>
 
     </platform>
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -53,8 +53,11 @@ xmlns:android="http://schemas.android.com/apk/res/android"
         <source-file src="src/ios/FirebaseAnalyticsPlugin.m" />
 
         <podspec>
-            <pods >
-                <pod name="Firebase/Analytics" spec="~> 8.6.0"/>
+            <config>
+                <source url="https://cdn.cocoapods.org/"/>
+            </config>
+            <pods>
+                <pod name="Firebase/Analytics" spec="$IOS_FIREBASE_ANALYTICS_VERSION" />
             </pods>
         </podspec>
 

--- a/www/FirebaseAnalytics.js
+++ b/www/FirebaseAnalytics.js
@@ -66,7 +66,6 @@ module.exports = {
                 }
             }
 
-
             exec(resolve, reject, PLUGIN_NAME, "requestTrackingAuthorization", [showInformation, title, message, buttonTitle]);
         });
     }


### PR DESCRIPTION
## Description
Updated Firebase library version to 8.6.0 on iOS, and 19.0.+ on iOS

## Context
The original issue was extended to upgrade Firebase/Crashlytics version. Because of this, we also needed to update the remaining Firebase plugins.
https://outsystemsrd.atlassian.net/browse/RMET-732

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [X] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [X] Android
- [X] iOS
- [ ] JavaScript

## Tests
Tested on MABS 7.1.

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [X] Pull request title follows the format `RNMT-XXXX <title>`
- [X] Code follows code style of this project
- [X] CHANGELOG.md file is correctly updated
- [X] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
