### PR TITLE
Feat: Custom Message for UserTracking permission

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -22,6 +22,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
 
     <preference name="ANALYTICS_COLLECTION_ENABLED" default="true" />
     <preference name="AUTOMATIC_SCREEN_REPORTING_ENABLED" default="true" />
+    <preference name="USER_TRACKING_DESCRIPTION_IOS" default="$(PRODUCT_NAME) needs your attention." />
 
     <dependency id="cordova-outsystems-firebase-core" url="https://github.com/OutSystems/cordova-outsystems-firebase-core.git#1.0.0"/>
 
@@ -46,7 +47,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
             <string>$AUTOMATIC_SCREEN_REPORTING_ENABLED</string>
         </config-file>
         <config-file target="*-Info.plist" parent="NSUserTrackingUsageDescription">
-            <string>$(PRODUCT_NAME) needs your attention.</string>
+            <string>$USER_TRACKING_DESCRIPTION_IOS</string>
         </config-file>
 
         <header-file src="src/ios/FirebaseAnalyticsPlugin.h" />


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Allow for dynamic input for NSUserTrackingUsageDescription

## Context
<!--- Why is this change required? What problem does it solve? -->
It is required so the developer can create custom messages for the permission request for user tracking.
<!--- Place the link to the issue here -->

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [x] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
Installed the plugin in a sample app and checked if the message that appears was the one defined in the extensibility configurations as a variable.
<!--- Include details of your test environment if relevant -->

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [ ] Pull request title follows the format `RNMT-XXXX <title>`
- [ ] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
