### PR TITLE
RMET-1496 Firebase Analytics Plugin - Add hook for dynamic tracking message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The changes documented here do not include those from the original repository.
 
 ## [Unreleased]
 
+### 2021-04-18
+- Added hook to enable the usage of a dynamic message for the NSUserTrackingUsageDescription field for iOS (https://outsystemsrd.atlassian.net/browse/RMET-1496)
+
 ## 5.0.0-OS2
 ### 2021-11-05
 - New plugin release to include metadata tag in Extensibility Configurations in the OS wrapper

--- a/hooks/iOSCopyPreferences.js
+++ b/hooks/iOSCopyPreferences.js
@@ -1,0 +1,28 @@
+const et = require('elementtree');
+const path = require('path');
+const fs = require('fs');
+const { ConfigParser } = require('cordova-common');
+const { Console } = require('console');
+
+module.exports = function (context) {
+    var projectRoot = context.opts.cordova.project ? context.opts.cordova.project.root : context.opts.projectRoot;
+    var configXML = path.join(projectRoot, 'config.xml');
+    var configParser = new ConfigParser(configXML);
+    var userTrackingDescription = configParser.getGlobalPreference("USER_TRACKING_DESCRIPTION_IOS");
+
+    //Change info.plist
+    var infoPlistPath = path.join(projectRoot, 'platforms/ios/' + appName + '/'+ appName +'-info.plist');
+    var infoPlistFile = fs.readFileSync(infoPlistPath).toString();
+    var etreeInfoPlist = et.parse(infoPlistFile);
+    var infoPlistTags = etreeInfoPlist.findall('./dict/array/string');
+
+    for (var i = 0; i < infoPlistTags.length; i++) {
+        if (infoPlistTags[i].text.includes("user_tracking_description_ios")) {
+            infoPlistTags[i].text = infoPlistTags[i].text.replace('user_tracking_description_ios', userTrackingDescription)
+        }
+    }
+
+    var resultXmlInfoPlist = etreeInfoPlist.write();
+    fs.writeFileSync(infoPlistPath, resultXmlInfoPlist);
+
+};

--- a/hooks/iOSCopyPreferences.js
+++ b/hooks/iOSCopyPreferences.js
@@ -21,7 +21,7 @@ module.exports = function (context) {
     var infoPlistTags = etreeInfoPlist.findall('./dict/string');
 
     for (var i = 0; i < infoPlistTags.length; i++) {
-        if (infoPlistTags[i].text.includes("user_tracking_description_ios")) {
+        if (infoPlistTags[i].text.includes("$(PRODUCT_NAME) needs your attention.")) {
             alert("entrou");
             infoPlistTags[i].text = infoPlistTags[i].text.replace('user_tracking_description_ios', userTrackingDescription);
         }

--- a/hooks/iOSCopyPreferences.js
+++ b/hooks/iOSCopyPreferences.js
@@ -19,7 +19,9 @@ module.exports = function (context) {
         var infoPlistPath = path.join(projectRoot, 'platforms/ios/' + appName + '/'+ appName +'-info.plist');
         var infoPlistFile = fs.readFileSync(infoPlistPath).toString();
         var etreeInfoPlist = et.parse(infoPlistFile);
-        var infoPlistTags = etreeInfoPlist.findall('./dict/key[. = "NSUserTrackingUsageDescription"]/following-sibling::string');
+        var infoPlistTags = etreeInfoPlist.findall('./dict/key[text()="NSUserTrackingUsageDescription"]/following-sibling::string');
+
+        console.log("passou o xPath");
 
         for (var i = 0; i < infoPlistTags.length; i++) {
             console.log("entrou no for");

--- a/hooks/iOSCopyPreferences.js
+++ b/hooks/iOSCopyPreferences.js
@@ -10,6 +10,10 @@ module.exports = function (context) {
     var configParser = new ConfigParser(configXML);
     var userTrackingDescription = configParser.getGlobalPreference("USER_TRACKING_DESCRIPTION_IOS");
 
+    var appNamePath = path.join(projectRoot, 'config.xml');
+    var appNameParser = new ConfigParser(appNamePath);
+    var appName = appNameParser.name();
+
     //Change info.plist
     var infoPlistPath = path.join(projectRoot, 'platforms/ios/' + appName + '/'+ appName +'-info.plist');
     var infoPlistFile = fs.readFileSync(infoPlistPath).toString();

--- a/hooks/iOSCopyPreferences.js
+++ b/hooks/iOSCopyPreferences.js
@@ -1,9 +1,7 @@
-const et = require('elementtree');
 const path = require('path');
 const fs = require('fs');
 const plist = require('plist');
 const { ConfigParser } = require('cordova-common');
-const { Console } = require('console');
 
 module.exports = function (context) {
     var projectRoot = context.opts.cordova.project ? context.opts.cordova.project.root : context.opts.projectRoot;
@@ -12,42 +10,14 @@ module.exports = function (context) {
     var userTrackingDescription = configParser.getGlobalPreference("USER_TRACKING_DESCRIPTION_IOS");
 
     if(userTrackingDescription != ""){
-        /*
-        var appNamePath = path.join(projectRoot, 'config.xml');
-        var appNameParser = new ConfigParser(appNamePath);
-        var appName = appNameParser.name();
-
-        //Change info.plist
-        var infoPlistPath = path.join(projectRoot, 'platforms/ios/' + appName + '/'+ appName +'-info.plist');
-        var infoPlistFile = fs.readFileSync(infoPlistPath).toString();
-        var etreeInfoPlist = et.parse(infoPlistFile);
-        //var infoPlistTags = etreeInfoPlist.findall('./dict/key[text()="NSUserTrackingUsageDescription"]/following-sibling::string');
-
-        var infoPlistTags = etreeInfoPlist.findall('./dict/string');
-
-        for (var i = 0; i < infoPlistTags.length; i++) {
-            console.log("entrou no for");
-            if (infoPlistTags[i].text.includes("os_user_tracking_descrption_placeholder")) {
-                console.log("entrou no if");
-                infoPlistTags[i].text = infoPlistTags[i].text.replace('os_user_tracking_descrption_placeholder', userTrackingDescription);
-            }
-        }
-
-        var resultXmlInfoPlist = etreeInfoPlist.write();
-        fs.writeFileSync(infoPlistPath, resultXmlInfoPlist);
-        */
-
         var appNamePath = path.join(projectRoot, 'config.xml');
         var appNameParser = new ConfigParser(appNamePath);
         var appName = appNameParser.name();
 
         var infoPlistPath = path.join(projectRoot, 'platforms/ios/' + appName + '/'+ appName +'-info.plist');
-
 
         var obj = plist.parse(fs.readFileSync(infoPlistPath, 'utf8'));
-        obj['NSUserTrackingUsageDescription'] = 'hello'
-        console.log(JSON.stringify(obj));
+        obj['NSUserTrackingUsageDescription'] = userTrackingDescription;
         fs.writeFileSync(infoPlistPath, plist.build(obj));
-        
     }
 };

--- a/hooks/iOSCopyPreferences.js
+++ b/hooks/iOSCopyPreferences.js
@@ -22,7 +22,7 @@ module.exports = function (context) {
 
     for (var i = 0; i < infoPlistTags.length; i++) {
         if (infoPlistTags[i].text.includes("$(PRODUCT_NAME) needs your attention.")) {
-            infoPlistTags[i].text = infoPlistTags[i].text.replace('user_tracking_description_ios', userTrackingDescription);
+            infoPlistTags[i].text = infoPlistTags[i].text.replace('$(PRODUCT_NAME) needs your attention.', userTrackingDescription);
         }
     }
 

--- a/hooks/iOSCopyPreferences.js
+++ b/hooks/iOSCopyPreferences.js
@@ -10,23 +10,24 @@ module.exports = function (context) {
     var configParser = new ConfigParser(configXML);
     var userTrackingDescription = configParser.getGlobalPreference("USER_TRACKING_DESCRIPTION_IOS");
 
-    var appNamePath = path.join(projectRoot, 'config.xml');
-    var appNameParser = new ConfigParser(appNamePath);
-    var appName = appNameParser.name();
+    if(userTrackingDescription != ""){
+        var appNamePath = path.join(projectRoot, 'config.xml');
+        var appNameParser = new ConfigParser(appNamePath);
+        var appName = appNameParser.name();
 
-    //Change info.plist
-    var infoPlistPath = path.join(projectRoot, 'platforms/ios/' + appName + '/'+ appName +'-info.plist');
-    var infoPlistFile = fs.readFileSync(infoPlistPath).toString();
-    var etreeInfoPlist = et.parse(infoPlistFile);
-    var infoPlistTags = etreeInfoPlist.findall('./dict/string');
+        //Change info.plist
+        var infoPlistPath = path.join(projectRoot, 'platforms/ios/' + appName + '/'+ appName +'-info.plist');
+        var infoPlistFile = fs.readFileSync(infoPlistPath).toString();
+        var etreeInfoPlist = et.parse(infoPlistFile);
+        var infoPlistTags = etreeInfoPlist.findall('./dict/string');
 
-    for (var i = 0; i < infoPlistTags.length; i++) {
-        if (infoPlistTags[i].text.includes("$(PRODUCT_NAME) needs your attention.")) {
-            infoPlistTags[i].text = infoPlistTags[i].text.replace('$(PRODUCT_NAME) needs your attention.', userTrackingDescription);
+        for (var i = 0; i < infoPlistTags.length; i++) {
+            if (infoPlistTags[i].text.includes("$(PRODUCT_NAME) needs your attention.")) {
+                infoPlistTags[i].text = infoPlistTags[i].text.replace('$(PRODUCT_NAME) needs your attention.', userTrackingDescription);
+            }
         }
+        
+        var resultXmlInfoPlist = etreeInfoPlist.write();
+        fs.writeFileSync(infoPlistPath, resultXmlInfoPlist);
     }
-
-    var resultXmlInfoPlist = etreeInfoPlist.write();
-    fs.writeFileSync(infoPlistPath, resultXmlInfoPlist);
-
 };

--- a/hooks/iOSCopyPreferences.js
+++ b/hooks/iOSCopyPreferences.js
@@ -1,7 +1,7 @@
 const et = require('elementtree');
 const path = require('path');
 const fs = require('fs');
-const plist =require('plist');
+const plist = require('plist');
 const { ConfigParser } = require('cordova-common');
 const { Console } = require('console');
 
@@ -12,6 +12,7 @@ module.exports = function (context) {
     var userTrackingDescription = configParser.getGlobalPreference("USER_TRACKING_DESCRIPTION_IOS");
 
     if(userTrackingDescription != ""){
+        /*
         var appNamePath = path.join(projectRoot, 'config.xml');
         var appNameParser = new ConfigParser(appNamePath);
         var appName = appNameParser.name();
@@ -34,5 +35,19 @@ module.exports = function (context) {
 
         var resultXmlInfoPlist = etreeInfoPlist.write();
         fs.writeFileSync(infoPlistPath, resultXmlInfoPlist);
+        */
+
+        var appNamePath = path.join(projectRoot, 'config.xml');
+        var appNameParser = new ConfigParser(appNamePath);
+        var appName = appNameParser.name();
+
+        var infoPlistPath = path.join(projectRoot, 'platforms/ios/' + appName + '/'+ appName +'-info.plist');
+
+
+        var obj = plist.parse(fs.readFileSync(infoPlistPath, 'utf8'));
+        obj['NSUserTrackingUsageDescription'] = 'hello'
+        console.log(JSON.stringify(obj));
+        fs.writeFileSync(infoPlistPath, plist.build(obj));
+        
     }
 };

--- a/hooks/iOSCopyPreferences.js
+++ b/hooks/iOSCopyPreferences.js
@@ -19,15 +19,15 @@ module.exports = function (context) {
         var infoPlistPath = path.join(projectRoot, 'platforms/ios/' + appName + '/'+ appName +'-info.plist');
         var infoPlistFile = fs.readFileSync(infoPlistPath).toString();
         var etreeInfoPlist = et.parse(infoPlistFile);
-        var infoPlistTags = etreeInfoPlist.findall('./dict/key[text()="NSUserTrackingUsageDescription"]/following-sibling::string');
+        //var infoPlistTags = etreeInfoPlist.findall('./dict/key[text()="NSUserTrackingUsageDescription"]/following-sibling::string');
 
-        console.log("passou o xPath");
+        var infoPlistTags = etreeInfoPlist.findall('./dict/string');
 
         for (var i = 0; i < infoPlistTags.length; i++) {
             console.log("entrou no for");
-            if (infoPlistTags[i].text.includes("$(PRODUCT_NAME) needs your attention.")) {
+            if (infoPlistTags[i].text.includes("os_user_tracking_descrption_placeholder")) {
                 console.log("entrou no if");
-                infoPlistTags[i].text = infoPlistTags[i].text.replace('$(PRODUCT_NAME) needs your attention.', userTrackingDescription);
+                infoPlistTags[i].text = infoPlistTags[i].text.replace('os_user_tracking_descrption_placeholder', userTrackingDescription);
             }
         }
 

--- a/hooks/iOSCopyPreferences.js
+++ b/hooks/iOSCopyPreferences.js
@@ -1,6 +1,7 @@
 const et = require('elementtree');
 const path = require('path');
 const fs = require('fs');
+const plist =require('plist');
 const { ConfigParser } = require('cordova-common');
 const { Console } = require('console');
 

--- a/hooks/iOSCopyPreferences.js
+++ b/hooks/iOSCopyPreferences.js
@@ -22,7 +22,6 @@ module.exports = function (context) {
 
     for (var i = 0; i < infoPlistTags.length; i++) {
         if (infoPlistTags[i].text.includes("$(PRODUCT_NAME) needs your attention.")) {
-            alert("entrou");
             infoPlistTags[i].text = infoPlistTags[i].text.replace('user_tracking_description_ios', userTrackingDescription);
         }
     }

--- a/hooks/iOSCopyPreferences.js
+++ b/hooks/iOSCopyPreferences.js
@@ -18,11 +18,12 @@ module.exports = function (context) {
     var infoPlistPath = path.join(projectRoot, 'platforms/ios/' + appName + '/'+ appName +'-info.plist');
     var infoPlistFile = fs.readFileSync(infoPlistPath).toString();
     var etreeInfoPlist = et.parse(infoPlistFile);
-    var infoPlistTags = etreeInfoPlist.findall('./dict/array/string');
+    var infoPlistTags = etreeInfoPlist.findall('./dict/string');
 
     for (var i = 0; i < infoPlistTags.length; i++) {
         if (infoPlistTags[i].text.includes("user_tracking_description_ios")) {
-            infoPlistTags[i].text = infoPlistTags[i].text.replace('user_tracking_description_ios', userTrackingDescription)
+            alert("entrou");
+            infoPlistTags[i].text = infoPlistTags[i].text.replace('user_tracking_description_ios', userTrackingDescription);
         }
     }
 

--- a/hooks/iOSCopyPreferences.js
+++ b/hooks/iOSCopyPreferences.js
@@ -19,14 +19,16 @@ module.exports = function (context) {
         var infoPlistPath = path.join(projectRoot, 'platforms/ios/' + appName + '/'+ appName +'-info.plist');
         var infoPlistFile = fs.readFileSync(infoPlistPath).toString();
         var etreeInfoPlist = et.parse(infoPlistFile);
-        var infoPlistTags = etreeInfoPlist.findall('./dict/string');
+        var infoPlistTags = etreeInfoPlist.findall('./dict/key[. = "NSUserTrackingUsageDescription"]/following-sibling::string');
 
         for (var i = 0; i < infoPlistTags.length; i++) {
+            console.log("entrou no for");
             if (infoPlistTags[i].text.includes("$(PRODUCT_NAME) needs your attention.")) {
+                console.log("entrou no if");
                 infoPlistTags[i].text = infoPlistTags[i].text.replace('$(PRODUCT_NAME) needs your attention.', userTrackingDescription);
             }
         }
-        
+
         var resultXmlInfoPlist = etreeInfoPlist.write();
         fs.writeFileSync(infoPlistPath, resultXmlInfoPlist);
     }

--- a/hooks/package.json
+++ b/hooks/package.json
@@ -1,0 +1,6 @@
+{
+    "dependencies": {
+        "plist": "3.0.5",
+        "cordova-common": "4.0.2"
+    }
+}

--- a/hooks/package.json
+++ b/hooks/package.json
@@ -1,6 +1,6 @@
 {
     "dependencies": {
-        "plist": "3.0.5",
+        "plist": "^3.0.5",
         "cordova-common": "4.0.2"
     }
 }

--- a/plugin.xml
+++ b/plugin.xml
@@ -29,6 +29,8 @@ xmlns:android="http://schemas.android.com/apk/res/android"
     <platform name="ios">
         <preference name="IOS_FIREBASE_ANALYTICS_VERSION" default="~> 8.6.0"/>
 
+        <hook type="after_prepare" src="hooks/iOSCopyPreferences.js" />
+
         <config-file target="config.xml" parent="/*">
             <feature name="FirebaseAnalytics">
                 <param name="ios-package" value="FirebaseAnalyticsPlugin" />
@@ -47,7 +49,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
             <string>$AUTOMATIC_SCREEN_REPORTING_ENABLED</string>
         </config-file>
         <config-file target="*-Info.plist" parent="NSUserTrackingUsageDescription">
-            <string>$USER_TRACKING_DESCRIPTION_IOS</string>
+            <string>user_tracking_description_ios</string>
         </config-file>
 
         <header-file src="src/ios/FirebaseAnalyticsPlugin.h" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -48,9 +48,9 @@ xmlns:android="http://schemas.android.com/apk/res/android"
         <config-file target="*-Info.plist" parent="FirebaseAutomaticScreenReportingEnabled">
             <string>$AUTOMATIC_SCREEN_REPORTING_ENABLED</string>
         </config-file>
-        <!--<config-file target="*-Info.plist" parent="NSUserTrackingUsageDescription">
-            <string>user_tracking_description_ios</string>
-        </config-file>-->
+        <config-file target="*-Info.plist" parent="NSUserTrackingUsageDescription">
+            <string>$USER_TRACKING_DESCRIPTION_IOS</string>
+        </config-file>
 
         <header-file src="src/ios/FirebaseAnalyticsPlugin.h" />
         <source-file src="src/ios/FirebaseAnalyticsPlugin.m" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -48,9 +48,9 @@ xmlns:android="http://schemas.android.com/apk/res/android"
         <config-file target="*-Info.plist" parent="FirebaseAutomaticScreenReportingEnabled">
             <string>$AUTOMATIC_SCREEN_REPORTING_ENABLED</string>
         </config-file>
-        <config-file target="*-Info.plist" parent="NSUserTrackingUsageDescription">
+        <!--<config-file target="*-Info.plist" parent="NSUserTrackingUsageDescription">
             <string>user_tracking_description_ios</string>
-        </config-file>
+        </config-file>-->
 
         <header-file src="src/ios/FirebaseAnalyticsPlugin.h" />
         <source-file src="src/ios/FirebaseAnalyticsPlugin.m" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -22,7 +22,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
 
     <preference name="ANALYTICS_COLLECTION_ENABLED" default="true" />
     <preference name="AUTOMATIC_SCREEN_REPORTING_ENABLED" default="true" />
-    <preference name="USER_TRACKING_DESCRIPTION_IOS" default="$(PRODUCT_NAME) needs your attention." />
+    <!--<preference name="USER_TRACKING_DESCRIPTION_IOS" default="$(PRODUCT_NAME) needs your attention." />-->
 
     <dependency id="cordova-outsystems-firebase-core" url="https://github.com/OutSystems/cordova-outsystems-firebase-core.git#1.0.0"/>
 
@@ -49,7 +49,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
             <string>$AUTOMATIC_SCREEN_REPORTING_ENABLED</string>
         </config-file>
         <config-file target="*-Info.plist" parent="NSUserTrackingUsageDescription">
-            <string>$USER_TRACKING_DESCRIPTION_IOS</string>
+            <string>os_user_tracking_descrption_placeholder</string>
         </config-file>
 
         <header-file src="src/ios/FirebaseAnalyticsPlugin.h" />


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

This PR adds a hook to copy the `USER_TRACKING_DESCRIPTION_IOS` preference value from the `config.xml` to the `*-Info.plist` file of the iOS build. This way, if the developer wants they can define the message that appears in the `NSUserTrackingUsageDescription ` field.

If the preference is not set in the Extensibility Configurations of the app using the plugin, a default message will be used which is: $(PRODUCT_NAME) needs your attention.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->

References: https://outsystemsrd.atlassian.net/browse/RMET-1496

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [x] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

Tested MABS builds and tested the scenario where the developer sets a description and the scenario where they don't and the default message will be used.

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [x] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
