### PR TITLE
RMET-1547 - Firebase Analytics Plugin - Fix default value for NSUserTrackingUsageDescription

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The changes documented here do not include those from the original repository.
 
 ## [Unreleased]
 
+### 2021-05-06
+- Fixed default value for NSUserTrackingUsageDescription in plugin.xml (https://outsystemsrd.atlassian.net/browse/RMET-1547)
+
 ## 5.0.0-OS3
 ## 2022-04-19
 - Hook to add google services dependency to build.gradle. [RMET-1497](https://outsystemsrd.atlassian.net/browse/RMET-1497)

--- a/plugin.xml
+++ b/plugin.xml
@@ -22,7 +22,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
 
     <preference name="ANALYTICS_COLLECTION_ENABLED" default="true" />
     <preference name="AUTOMATIC_SCREEN_REPORTING_ENABLED" default="true" />
-    <!--<preference name="USER_TRACKING_DESCRIPTION_IOS" default="$(PRODUCT_NAME) needs your attention." />-->
+    <preference name="USER_TRACKING_DESCRIPTION_IOS" default="$(PRODUCT_NAME) needs your attention." />
 
     <dependency id="cordova-outsystems-firebase-core" url="https://github.com/OutSystems/cordova-outsystems-firebase-core.git#1.0.0"/>
 
@@ -49,7 +49,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
             <string>$AUTOMATIC_SCREEN_REPORTING_ENABLED</string>
         </config-file>
         <config-file target="*-Info.plist" parent="NSUserTrackingUsageDescription">
-            <string>os_user_tracking_descrption_placeholder</string>
+            <string>$USER_TRACKING_DESCRIPTION_IOS</string>
         </config-file>
 
         <header-file src="src/ios/FirebaseAnalyticsPlugin.h" />


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This PR fixes the default value for NSUserTrackingUsageDescription. If this isn't set as a preference in the Extensibility Configurations of the OS app, the default value is used and it's content wasn't correct.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->

https://outsystemsrd.atlassian.net/browse/RMET-1547

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [x] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->
MABS 8 builds working. Tested in iOS 14 using the default value and using a custom value coming from the preference.

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
