### PR TITLE
RMET-1547 Firebase Analytics Plugin - Make NSUserTrackingUsageDescription optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The changes documented here do not include those from the original repository.
 
 ## [Unreleased]
 
+### 2021-05-09
+- Made NSUserTrackingUsageDescription optional in .plist file (https://outsystemsrd.atlassian.net/browse/RMET-1547)
+
 ### 2021-05-06
 - Fixed default value for NSUserTrackingUsageDescription in plugin.xml (https://outsystemsrd.atlassian.net/browse/RMET-1547)
 

--- a/hooks/ios/iOSCopyPreferences.js
+++ b/hooks/ios/iOSCopyPreferences.js
@@ -2,22 +2,28 @@ const path = require('path');
 const fs = require('fs');
 const plist = require('plist');
 const { ConfigParser } = require('cordova-common');
+const { config } = require('process');
 
 module.exports = function (context) {
     var projectRoot = context.opts.cordova.project ? context.opts.cordova.project.root : context.opts.projectRoot;
     var configXML = path.join(projectRoot, 'config.xml');
     var configParser = new ConfigParser(configXML);
-    var userTrackingDescription = configParser.getGlobalPreference("USER_TRACKING_DESCRIPTION_IOS");
+    var enableAppTracking = configParser.getPlatformPreference("EnableAppTrackingTransparencyPrompt", "ios");
 
-    if(userTrackingDescription != ""){
-        var appNamePath = path.join(projectRoot, 'config.xml');
-        var appNameParser = new ConfigParser(appNamePath);
-        var appName = appNameParser.name();
+    var appNamePath = path.join(projectRoot, 'config.xml');
+    var appNameParser = new ConfigParser(appNamePath);
+    var appName = appNameParser.name();
+    var infoPlistPath = path.join(projectRoot, 'platforms/ios/' + appName + '/'+ appName +'-info.plist');
+    var obj = plist.parse(fs.readFileSync(infoPlistPath, 'utf8'));
 
-        var infoPlistPath = path.join(projectRoot, 'platforms/ios/' + appName + '/'+ appName +'-info.plist');
-
-        var obj = plist.parse(fs.readFileSync(infoPlistPath, 'utf8'));
-        obj['NSUserTrackingUsageDescription'] = userTrackingDescription;
-        fs.writeFileSync(infoPlistPath, plist.build(obj));
+    if(enableAppTracking == true){
+        if(userTrackingDescription != ""){
+            var userTrackingDescription = configParser.getPlatformPreference("USER_TRACKING_DESCRIPTION_IOS", "ios");
+            obj['NSUserTrackingUsageDescription'] = userTrackingDescription;
+        }
     }
+    else{
+        obj['NSUserTrackingUsageDescription'] = null;
+    }
+    fs.writeFileSync(infoPlistPath, plist.build(obj));
 };

--- a/hooks/ios/iOSCopyPreferences.js
+++ b/hooks/ios/iOSCopyPreferences.js
@@ -17,8 +17,8 @@ module.exports = function (context) {
     var obj = plist.parse(fs.readFileSync(infoPlistPath, 'utf8'));
 
     if(enableAppTracking == "true" || enableAppTracking == ""){
+        var userTrackingDescription = configParser.getPlatformPreference("USER_TRACKING_DESCRIPTION_IOS", "ios");
         if(userTrackingDescription != ""){
-            var userTrackingDescription = configParser.getPlatformPreference("USER_TRACKING_DESCRIPTION_IOS", "ios");
             obj['NSUserTrackingUsageDescription'] = userTrackingDescription;
             fs.writeFileSync(infoPlistPath, plist.build(obj));
         }

--- a/hooks/ios/iOSCopyPreferences.js
+++ b/hooks/ios/iOSCopyPreferences.js
@@ -10,13 +10,15 @@ module.exports = function (context) {
     var configParser = new ConfigParser(configXML);
     var enableAppTracking = configParser.getPlatformPreference("EnableAppTrackingTransparencyPrompt", "ios");
 
+    console.log("ENABLE_TRACKING" + enableAppTracking);
+
     var appNamePath = path.join(projectRoot, 'config.xml');
     var appNameParser = new ConfigParser(appNamePath);
     var appName = appNameParser.name();
     var infoPlistPath = path.join(projectRoot, 'platforms/ios/' + appName + '/'+ appName +'-info.plist');
     var obj = plist.parse(fs.readFileSync(infoPlistPath, 'utf8'));
 
-    if(enableAppTracking == true){
+    if(enableAppTracking == "true"){
         if(userTrackingDescription != ""){
             var userTrackingDescription = configParser.getPlatformPreference("USER_TRACKING_DESCRIPTION_IOS", "ios");
             obj['NSUserTrackingUsageDescription'] = userTrackingDescription;

--- a/hooks/ios/iOSCopyPreferences.js
+++ b/hooks/ios/iOSCopyPreferences.js
@@ -9,7 +9,7 @@ module.exports = function (context) {
     var configXML = path.join(projectRoot, 'config.xml');
     var configParser = new ConfigParser(configXML);
     var enableAppTracking = configParser.getPlatformPreference("EnableAppTrackingTransparencyPrompt", "ios");
-    
+
     var appNamePath = path.join(projectRoot, 'config.xml');
     var appNameParser = new ConfigParser(appNamePath);
     var appName = appNameParser.name();
@@ -20,10 +20,11 @@ module.exports = function (context) {
         if(userTrackingDescription != ""){
             var userTrackingDescription = configParser.getPlatformPreference("USER_TRACKING_DESCRIPTION_IOS", "ios");
             obj['NSUserTrackingUsageDescription'] = userTrackingDescription;
+            fs.writeFileSync(infoPlistPath, plist.build(obj));
         }
     }
     else{
         delete obj['NSUserTrackingUsageDescription'];
+        fs.writeFileSync(infoPlistPath, plist.build(obj));
     }
-    fs.writeFileSync(infoPlistPath, plist.build(obj));
 };

--- a/hooks/ios/iOSCopyPreferences.js
+++ b/hooks/ios/iOSCopyPreferences.js
@@ -8,7 +8,7 @@ module.exports = function (context) {
     var projectRoot = context.opts.cordova.project ? context.opts.cordova.project.root : context.opts.projectRoot;
     var configXML = path.join(projectRoot, 'config.xml');
     var configParser = new ConfigParser(configXML);
-    var enableAppTracking = configParser.getGlobalPreference("EnableAppTrackingTransparencyPrompt");
+    var enableAppTracking = configParser.getPlatformPreference("EnableAppTrackingTransparencyPrompt", "ios");
 
     var appNamePath = path.join(projectRoot, 'config.xml');
     var appNameParser = new ConfigParser(appNamePath);
@@ -18,7 +18,7 @@ module.exports = function (context) {
 
     if(enableAppTracking == true){
         if(userTrackingDescription != ""){
-            var userTrackingDescription = configParser.getGlobalPreference("USER_TRACKING_DESCRIPTION_IOS");
+            var userTrackingDescription = configParser.getPlatformPreference("USER_TRACKING_DESCRIPTION_IOS", "ios");
             obj['NSUserTrackingUsageDescription'] = userTrackingDescription;
         }
     }

--- a/hooks/ios/iOSCopyPreferences.js
+++ b/hooks/ios/iOSCopyPreferences.js
@@ -23,10 +23,11 @@ module.exports = function (context) {
         }
     }
     else{
-        var index = obj.indexOf('NSUserTrackingUsageDescription');
-        if (index !== -1) {
-            obj.splice(index, 1);
-        }
+        //var index = obj.indexOf('NSUserTrackingUsageDescription');
+        //if (index !== -1) {
+        //    obj.splice(index, 1);
+        //}
+        console.log(obj);
     }
     fs.writeFileSync(infoPlistPath, plist.build(obj));
 };

--- a/hooks/ios/iOSCopyPreferences.js
+++ b/hooks/ios/iOSCopyPreferences.js
@@ -2,7 +2,6 @@ const path = require('path');
 const fs = require('fs');
 const plist = require('plist');
 const { ConfigParser } = require('cordova-common');
-const { config } = require('process');
 
 module.exports = function (context) {
     var projectRoot = context.opts.cordova.project ? context.opts.cordova.project.root : context.opts.projectRoot;

--- a/hooks/ios/iOSCopyPreferences.js
+++ b/hooks/ios/iOSCopyPreferences.js
@@ -23,7 +23,10 @@ module.exports = function (context) {
         }
     }
     else{
-        obj['NSUserTrackingUsageDescription'] = null;
+        var index = obj.indexOf('NSUserTrackingUsageDescription');
+        if (index !== -1) {
+            obj.splice(index, 1);
+        }
     }
     fs.writeFileSync(infoPlistPath, plist.build(obj));
 };

--- a/hooks/ios/iOSCopyPreferences.js
+++ b/hooks/ios/iOSCopyPreferences.js
@@ -9,9 +9,7 @@ module.exports = function (context) {
     var configXML = path.join(projectRoot, 'config.xml');
     var configParser = new ConfigParser(configXML);
     var enableAppTracking = configParser.getPlatformPreference("EnableAppTrackingTransparencyPrompt", "ios");
-
-    console.log("ENABLE_TRACKING" + enableAppTracking);
-
+    
     var appNamePath = path.join(projectRoot, 'config.xml');
     var appNameParser = new ConfigParser(appNamePath);
     var appName = appNameParser.name();

--- a/hooks/ios/iOSCopyPreferences.js
+++ b/hooks/ios/iOSCopyPreferences.js
@@ -23,13 +23,7 @@ module.exports = function (context) {
         }
     }
     else{
-        //var index = obj.indexOf('NSUserTrackingUsageDescription');
-        //if (index !== -1) {
-        //    obj.splice(index, 1);
-        //}
-        console.log(obj);
         delete obj['NSUserTrackingUsageDescription'];
-        console.log(obj);
     }
     fs.writeFileSync(infoPlistPath, plist.build(obj));
 };

--- a/hooks/ios/iOSCopyPreferences.js
+++ b/hooks/ios/iOSCopyPreferences.js
@@ -16,14 +16,14 @@ module.exports = function (context) {
     var infoPlistPath = path.join(projectRoot, 'platforms/ios/' + appName + '/'+ appName +'-info.plist');
     var obj = plist.parse(fs.readFileSync(infoPlistPath, 'utf8'));
 
-    if(enableAppTracking == "true"){
+    if(enableAppTracking == "true" || enableAppTracking == ""){
         if(userTrackingDescription != ""){
             var userTrackingDescription = configParser.getPlatformPreference("USER_TRACKING_DESCRIPTION_IOS", "ios");
             obj['NSUserTrackingUsageDescription'] = userTrackingDescription;
             fs.writeFileSync(infoPlistPath, plist.build(obj));
         }
     }
-    else{
+    else if(enableAppTracking == "false"){
         delete obj['NSUserTrackingUsageDescription'];
         fs.writeFileSync(infoPlistPath, plist.build(obj));
     }

--- a/hooks/ios/iOSCopyPreferences.js
+++ b/hooks/ios/iOSCopyPreferences.js
@@ -28,6 +28,8 @@ module.exports = function (context) {
         //    obj.splice(index, 1);
         //}
         console.log(obj);
+        delete obj['NSUserTrackingUsageDescription'];
+        console.log(obj);
     }
     fs.writeFileSync(infoPlistPath, plist.build(obj));
 };

--- a/hooks/ios/iOSCopyPreferences.js
+++ b/hooks/ios/iOSCopyPreferences.js
@@ -8,7 +8,7 @@ module.exports = function (context) {
     var projectRoot = context.opts.cordova.project ? context.opts.cordova.project.root : context.opts.projectRoot;
     var configXML = path.join(projectRoot, 'config.xml');
     var configParser = new ConfigParser(configXML);
-    var enableAppTracking = configParser.getPlatformPreference("EnableAppTrackingTransparencyPrompt", "ios");
+    var enableAppTracking = configParser.getGlobalPreference("EnableAppTrackingTransparencyPrompt");
 
     var appNamePath = path.join(projectRoot, 'config.xml');
     var appNameParser = new ConfigParser(appNamePath);
@@ -18,7 +18,7 @@ module.exports = function (context) {
 
     if(enableAppTracking == true){
         if(userTrackingDescription != ""){
-            var userTrackingDescription = configParser.getPlatformPreference("USER_TRACKING_DESCRIPTION_IOS", "ios");
+            var userTrackingDescription = configParser.getGlobalPreference("USER_TRACKING_DESCRIPTION_IOS");
             obj['NSUserTrackingUsageDescription'] = userTrackingDescription;
         }
     }

--- a/src/ios/FirebaseAnalyticsPlugin.m
+++ b/src/ios/FirebaseAnalyticsPlugin.m
@@ -101,21 +101,30 @@
 - (void)showTrackingAuthorizationPopup:(CDVInvokedUrlCommand *)command {
     
     if (@available(iOS 14, *)) {
-        [ATTrackingManager requestTrackingAuthorizationWithCompletionHandler:^(ATTrackingManagerAuthorizationStatus status) {
-            BOOL result = false;
-            switch(status) {
-                case ATTrackingManagerAuthorizationStatusAuthorized: {
-                    result = true;
-                    break;
+        
+        NSDictionary *dict = NSBundle.mainBundle.infoDictionary;
+        
+        if([dict objectForKey:@"NSUserTrackingUsageDescription"]){
+            [ATTrackingManager requestTrackingAuthorizationWithCompletionHandler:^(ATTrackingManagerAuthorizationStatus status) {
+                BOOL result = false;
+                switch(status) {
+                    case ATTrackingManagerAuthorizationStatusAuthorized: {
+                        result = true;
+                        break;
+                    }
+                    default: {
+                        result = false;
+                        break;
+                    }
                 }
-                default: {
-                    result = false;
-                    break;
-                }
-            }
-            CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsBool:result];
+                CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsBool:result];
+                [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+            }];
+        }
+        else{
+            CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"App Tracking Transparency prompt not enabled."];
             [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
-        }];
+        }
     }
     else {
         CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsBool:true];

--- a/src/ios/FirebaseAnalyticsPlugin.m
+++ b/src/ios/FirebaseAnalyticsPlugin.m
@@ -122,7 +122,7 @@
             }];
         }
         else{
-            CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"App Tracking Transparency prompt not enabled."];
+            CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsBool:true];
             [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
         }
     }

--- a/src/ios/FirebaseAnalyticsPlugin.m
+++ b/src/ios/FirebaseAnalyticsPlugin.m
@@ -111,16 +111,12 @@
                 CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsBool:result];
                 [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
             }];
-        }
-        else{
-            CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsBool:true];
-            [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+            return;
         }
     }
-    else {
-        CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsBool:true];
-        [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
-    }
+    
+    CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsBool:true];
+    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
 
 typedef void (^showPermissionInformationPopupHandler)(UIAlertAction*);

--- a/src/ios/FirebaseAnalyticsPlugin.m
+++ b/src/ios/FirebaseAnalyticsPlugin.m
@@ -106,17 +106,8 @@
         
         if([dict objectForKey:@"NSUserTrackingUsageDescription"]){
             [ATTrackingManager requestTrackingAuthorizationWithCompletionHandler:^(ATTrackingManagerAuthorizationStatus status) {
-                BOOL result = false;
-                switch(status) {
-                    case ATTrackingManagerAuthorizationStatusAuthorized: {
-                        result = true;
-                        break;
-                    }
-                    default: {
-                        result = false;
-                        break;
-                    }
-                }
+                BOOL result = status == ATTrackingManagerAuthorizationStatusAuthorized;
+                
                 CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsBool:result];
                 [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
             }];

--- a/www/FirebaseAnalytics.js
+++ b/www/FirebaseAnalytics.js
@@ -48,23 +48,25 @@ module.exports = {
 
             exec(resolve, reject, PLUGIN_NAME, "setDefaultEventParameters", [defaults || {}]);
         });
+    },
+    requestTrackingAuthorization: function(success, error, showInformation, title, message, buttonTitle) {
+        return new Promise(function(resolve, reject) {
+
+            if(showInformation) {
+                if (typeof title !== "string") {
+                    return reject(new TypeError("Title property name must be a string"));
+                }
+    
+                if (typeof message !== "string") {
+                    return reject(new TypeError("Message property value must be a string"));
+                }
+    
+                if (typeof buttonTitle !== "string") {
+                    return reject(new TypeError("Button title property value must be a string"));
+                }
+            }
+
+            exec(resolve, reject, PLUGIN_NAME, "requestTrackingAuthorization", [showInformation, title, message, buttonTitle]);
+        });
     }
-};
-
-exports.requestTrackingAuthorization = function (success, error, showInformation, title, message, buttonTitle) {
-
-    if(showInformation) {
-        if (typeof title !== "string") {
-            return error(new TypeError("Title property name must be a string"));
-        }
-
-        if (typeof message !== "string") {
-            return error(new TypeError("Message property value must be a string"));
-        }
-
-        if (typeof buttonTitle !== "string") {
-            return error(new TypeError("Button title property value must be a string"));
-        }
-    }
-    exec(success, error, PLUGIN_NAME, 'requestTrackingAuthorization', [showInformation, title, message, buttonTitle]);
 };

--- a/www/FirebaseAnalytics.js
+++ b/www/FirebaseAnalytics.js
@@ -49,7 +49,7 @@ module.exports = {
             exec(resolve, reject, PLUGIN_NAME, "setDefaultEventParameters", [defaults || {}]);
         });
     },
-    requestTrackingAuthorization: function(showInformation, title, message, buttonTitle) {
+    requestTrackingAuthorization: function(success, error, showInformation, title, message, buttonTitle) {
         return new Promise(function(resolve, reject) {
 
             if(showInformation) {

--- a/www/FirebaseAnalytics.js
+++ b/www/FirebaseAnalytics.js
@@ -48,25 +48,23 @@ module.exports = {
 
             exec(resolve, reject, PLUGIN_NAME, "setDefaultEventParameters", [defaults || {}]);
         });
-    },
-    requestTrackingAuthorization: function(success, error, showInformation, title, message, buttonTitle) {
-        return new Promise(function(resolve, reject) {
-
-            if(showInformation) {
-                if (typeof title !== "string") {
-                    return reject(new TypeError("Title property name must be a string"));
-                }
-    
-                if (typeof message !== "string") {
-                    return reject(new TypeError("Message property value must be a string"));
-                }
-    
-                if (typeof buttonTitle !== "string") {
-                    return reject(new TypeError("Button title property value must be a string"));
-                }
-            }
-
-            exec(resolve, reject, PLUGIN_NAME, "requestTrackingAuthorization", [showInformation, title, message, buttonTitle]);
-        });
     }
+};
+
+exports.requestTrackingAuthorization = function (success, error, showInformation, title, message, buttonTitle) {
+
+    if(showInformation) {
+        if (typeof title !== "string") {
+            return error(new TypeError("Title property name must be a string"));
+        }
+
+        if (typeof message !== "string") {
+            return error(new TypeError("Message property value must be a string"));
+        }
+
+        if (typeof buttonTitle !== "string") {
+            return error(new TypeError("Button title property value must be a string"));
+        }
+    }
+    exec(success, error, PLUGIN_NAME, 'requestTrackingAuthorization', [showInformation, title, message, buttonTitle]);
 };


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

- This PR makes `NSUserTrackingUsageDescription` optional in the *-Info.plist file. If the EnableAppTrackingTransparencyPrompt is set as "false", then we remove it from the .plist file. If it is set to "true" or "" (empty - means that it isn't present in the Extensibility Configurations) we keep it.
- It also alters the obj-c code for `showTrackingAuthorizationPopup` so that it only calls the native prompt if the .plist file contains `NSUserTrackingUsageDescription`. If not, it does nothing. If we kept launching the prompt without having `NSUserTrackingUsageDescription`, the app would crash.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->
References: https://outsystemsrd.atlassian.net/browse/RMET-1547

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [x] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->
Tested MABS builds and tested all scenarios in an iPhone 11 running iOS 15.

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
