### PR TITLE
RMET-1715 Analytics Plugin - Remove unused success and error parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The changes documented here do not include those from the original repository.
 
 ## [Unreleased]
 
+### 2021-07-12
+- Removed unused parameters from RequestTrackingAuthorization (https://outsystemsrd.atlassian.net/browse/RMET-1715)
+
 ## 5.0.0-OS5
 ### 2021-05-16
 - Update dependency to firebase-core to have error message improved (https://outsystemsrd.atlassian.net/browse/RMET-1538)

--- a/www/FirebaseAnalytics.js
+++ b/www/FirebaseAnalytics.js
@@ -49,7 +49,7 @@ module.exports = {
             exec(resolve, reject, PLUGIN_NAME, "setDefaultEventParameters", [defaults || {}]);
         });
     },
-    requestTrackingAuthorization: function(success, error, showInformation, title, message, buttonTitle) {
+    requestTrackingAuthorization: function(showInformation, title, message, buttonTitle) {
         return new Promise(function(resolve, reject) {
 
             if(showInformation) {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This PR removes the success and error parameters from the requestTrackingAuthorization since these aren't used. This together with a fix in the plugin's wrapper, fixes the reported bug in the Context section.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->

References: https://outsystemsrd.atlassian.net/browse/RMET-1715

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [x] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->
Tested MABS builds. Tested on iOS 15.5 (iPhone 11 device).

## Screenshots (if appropriate)


## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
