### PR TITLE
RMET-2112 FB Analytics - Return user's response to App Tracking Transparency prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The changes documented here do not include those from the original repository.
 
 ## [Unreleased]
 
+### 2023-01-12
+- Feat: Return user's response to prompt [RMET-2112](https://outsystemsrd.atlassian.net/browse/RMET-2112)
+
 ## 5.0.0-OS8
 
 ### 2022-10-31

--- a/www/FirebaseAnalytics.js
+++ b/www/FirebaseAnalytics.js
@@ -49,7 +49,9 @@ module.exports = {
             exec(resolve, reject, PLUGIN_NAME, "setDefaultEventParameters", [defaults || {}]);
         });
     },
-    requestTrackingAuthorization: function(showInformation, title, message, buttonTitle, success, error) {
+    requestTrackingAuthorization: function(showInformation, title, message, buttonTitle) {
+        return new Promise(function(resolve, reject) {
+
             if(showInformation) {
                 if (typeof title !== "string") {
                     return reject(new TypeError("Title property name must be a string"));
@@ -63,6 +65,8 @@ module.exports = {
                     return reject(new TypeError("Button title property value must be a string"));
                 }
             }
-            exec(success, error, PLUGIN_NAME, "requestTrackingAuthorization", [showInformation, title, message, buttonTitle]);
+
+            exec(resolve, reject, PLUGIN_NAME, "requestTrackingAuthorization", [showInformation, title, message, buttonTitle]);
+        });
     }
 };

--- a/www/FirebaseAnalytics.js
+++ b/www/FirebaseAnalytics.js
@@ -1,7 +1,6 @@
 var exec = require("cordova/exec");
 var PLUGIN_NAME = "FirebaseAnalytics";
 
-/*
 module.exports = {
     logEvent: function(name, params) {
         return new Promise(function(resolve, reject) {
@@ -50,29 +49,13 @@ module.exports = {
             exec(resolve, reject, PLUGIN_NAME, "setDefaultEventParameters", [defaults || {}]);
         });
     },
-    requestTrackingAuthorization: function(showInformation, title, message, buttonTitle) {
-        return new Promise(function(resolve, reject) {
-
-            if(showInformation) {
-                if (typeof title !== "string") {
-                    return reject(new TypeError("Title property name must be a string"));
-                }
-    
-                if (typeof message !== "string") {
-                    return reject(new TypeError("Message property value must be a string"));
-                }
-    
-                if (typeof buttonTitle !== "string") {
-                    return reject(new TypeError("Button title property value must be a string"));
-                }
-            }
-
-            exec(resolve, reject, PLUGIN_NAME, "requestTrackingAuthorization", [showInformation, title, message, buttonTitle]);
-        });
+    requestTrackingAuthorization: function(showInformation, title, message, buttonTitle, success, error) {
+        exec(success, error, 'FirebaseAnalytics', 'requestTrackingAuthorization', [showInformation, title, message, buttonTitle]);
     }
 };
-*/
 
+/*
 exports.requestTrackingAuthorization = function(showInformation, title, message, buttonTitle, success, error) {
     exec(success, error, 'FirebaseAnalytics', 'requestTrackingAuthorization', [showInformation, title, message, buttonTitle]);
 }
+*/

--- a/www/FirebaseAnalytics.js
+++ b/www/FirebaseAnalytics.js
@@ -49,6 +49,7 @@ module.exports = {
             exec(resolve, reject, PLUGIN_NAME, "setDefaultEventParameters", [defaults || {}]);
         });
     },
+    /*
     requestTrackingAuthorization: function(showInformation, title, message, buttonTitle) {
         return new Promise(function(resolve, reject) {
 
@@ -69,4 +70,24 @@ module.exports = {
             exec(resolve, reject, PLUGIN_NAME, "requestTrackingAuthorization", [showInformation, title, message, buttonTitle]);
         });
     }
+    */
 };
+
+exports.requestTrackingAuthorization = function(showInformation, title, message, buttonTitle, success, error) {
+
+    if(showInformation) {
+        if (typeof title !== "string") {
+            return error(new TypeError("Title property name must be a string"));
+        }
+
+        if (typeof message !== "string") {
+            return error(new TypeError("Message property value must be a string"));
+        }
+
+        if (typeof buttonTitle !== "string") {
+            return error(new TypeError("Button title property value must be a string"));
+        }
+    }
+
+    exec(success, error, PLUGIN_NAME, 'requestTrackingAuthorization', [showInformation, title, message, buttonTitle]);
+}

--- a/www/FirebaseAnalytics.js
+++ b/www/FirebaseAnalytics.js
@@ -50,6 +50,6 @@ module.exports = {
         });
     },
     requestTrackingAuthorization: function(showInformation, title, message, buttonTitle, success, error) {
-        exec(success, error, 'FirebaseAnalytics', 'requestTrackingAuthorization', [showInformation, title, message, buttonTitle]);
+        exec(success, error, PLUGIN_NAME, 'requestTrackingAuthorization', [showInformation, title, message, buttonTitle]);
     }
 };

--- a/www/FirebaseAnalytics.js
+++ b/www/FirebaseAnalytics.js
@@ -49,10 +49,7 @@ module.exports = {
             exec(resolve, reject, PLUGIN_NAME, "setDefaultEventParameters", [defaults || {}]);
         });
     },
-    /*
-    requestTrackingAuthorization: function(showInformation, title, message, buttonTitle) {
-        return new Promise(function(resolve, reject) {
-
+    requestTrackingAuthorization: function(showInformation, title, message, buttonTitle, success, error) {
             if(showInformation) {
                 if (typeof title !== "string") {
                     return reject(new TypeError("Title property name must be a string"));
@@ -66,28 +63,6 @@ module.exports = {
                     return reject(new TypeError("Button title property value must be a string"));
                 }
             }
-
-            exec(resolve, reject, PLUGIN_NAME, "requestTrackingAuthorization", [showInformation, title, message, buttonTitle]);
-        });
+            exec(success, error, PLUGIN_NAME, "requestTrackingAuthorization", [showInformation, title, message, buttonTitle]);
     }
-    */
 };
-
-exports.requestTrackingAuthorization = function(showInformation, title, message, buttonTitle, success, error) {
-
-    if(showInformation) {
-        if (typeof title !== "string") {
-            return error(new TypeError("Title property name must be a string"));
-        }
-
-        if (typeof message !== "string") {
-            return error(new TypeError("Message property value must be a string"));
-        }
-
-        if (typeof buttonTitle !== "string") {
-            return error(new TypeError("Button title property value must be a string"));
-        }
-    }
-
-    exec(success, error, PLUGIN_NAME, 'requestTrackingAuthorization', [showInformation, title, message, buttonTitle]);
-}

--- a/www/FirebaseAnalytics.js
+++ b/www/FirebaseAnalytics.js
@@ -53,9 +53,3 @@ module.exports = {
         exec(success, error, 'FirebaseAnalytics', 'requestTrackingAuthorization', [showInformation, title, message, buttonTitle]);
     }
 };
-
-/*
-exports.requestTrackingAuthorization = function(showInformation, title, message, buttonTitle, success, error) {
-    exec(success, error, 'FirebaseAnalytics', 'requestTrackingAuthorization', [showInformation, title, message, buttonTitle]);
-}
-*/

--- a/www/FirebaseAnalytics.js
+++ b/www/FirebaseAnalytics.js
@@ -1,6 +1,7 @@
 var exec = require("cordova/exec");
 var PLUGIN_NAME = "FirebaseAnalytics";
 
+/*
 module.exports = {
     logEvent: function(name, params) {
         return new Promise(function(resolve, reject) {
@@ -70,3 +71,8 @@ module.exports = {
         });
     }
 };
+*/
+
+exports.requestTrackingAuthorization = function(showInformation, title, message, buttonTitle, success, error) {
+    exec(success, error, 'FirebaseAnalytics', 'requestTrackingAuthorization', [showInformation, title, message, buttonTitle]);
+}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

- This PR removes the `Promise` object form the `requestTrackingTransparency` function on the plugin's JS layer, as we want the call to this function to be made synchronously.
- It also adds `success` and `error` callbacks.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->
References: https://outsystemsrd.atlassian.net/browse/RMET-2112

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [ ] iOS
- [x] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->
Tested on MABS 9 and MABS 8 builds, in iPhone 11 running iOS 16.2.

## Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/27646996/212110564-79c63565-c8be-43d9-a610-ed54e9c83bf7.png)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
