### PR TITLE
RMET-2441 :: raise firebase-core version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The changes documented here do not include those from the original repository.
 
 ## [Unreleased]
 
+## 5.0.0-OS9
+
 ### 2023-01-12
 - Feat: Return user's response to prompt [RMET-2112](https://outsystemsrd.atlassian.net/browse/RMET-2112)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The changes documented here do not include those from the original repository.
 
 ## [Unreleased]
 
+### 2023-01-12
+- Feat: Return user's response to prompt [RMET-2112](https://outsystemsrd.atlassian.net/browse/RMET-2112)
+
 ## 5.0.0-OS8
 
 ### 2022-10-31

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The changes documented here do not include those from the original repository.
 
 ## [Unreleased]
+- Feat: update firebase core version (https://outsystemsrd.atlassian.net/browse/RMET-2451).
 
 ## 5.0.0-OS9
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-firebase-analytics",
-  "version": "5.0.0-OS8",
+  "version": "5.0.0-OS9",
   "description": "Cordova plugin for Firebase Analytics",
   "cordova": {
     "id": "cordova-plugin-firebase-analytics",

--- a/plugin.xml
+++ b/plugin.xml
@@ -24,7 +24,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
     <preference name="AUTOMATIC_SCREEN_REPORTING_ENABLED" default="true" />
     <preference name="USER_TRACKING_DESCRIPTION_IOS" default="$(PRODUCT_NAME) needs your attention." />
 
-    <dependency id="cordova-outsystems-firebase-core" url="https://github.com/OutSystems/cordova-outsystems-firebase-core.git#1.0.1"/>
+    <dependency id="cordova-outsystems-firebase-core" url="https://github.com/OutSystems/cordova-outsystems-firebase-core.git#2.0.0"/>
 
     <platform name="ios">
         <preference name="IOS_FIREBASE_ANALYTICS_VERSION" default="~> 8.6.0"/>

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
 xmlns:android="http://schemas.android.com/apk/res/android"
            id="cordova-plugin-firebase-analytics"
-      version="5.0.0-OS8">
+      version="5.0.0-OS9">
 
     <name>FirebaseAnalyticsPlugin</name>
     <description>Cordova plugin for Firebase Analytics</description>

--- a/www/FirebaseAnalytics.js
+++ b/www/FirebaseAnalytics.js
@@ -49,24 +49,7 @@ module.exports = {
             exec(resolve, reject, PLUGIN_NAME, "setDefaultEventParameters", [defaults || {}]);
         });
     },
-    requestTrackingAuthorization: function(showInformation, title, message, buttonTitle) {
-        return new Promise(function(resolve, reject) {
-
-            if(showInformation) {
-                if (typeof title !== "string") {
-                    return reject(new TypeError("Title property name must be a string"));
-                }
-    
-                if (typeof message !== "string") {
-                    return reject(new TypeError("Message property value must be a string"));
-                }
-    
-                if (typeof buttonTitle !== "string") {
-                    return reject(new TypeError("Button title property value must be a string"));
-                }
-            }
-
-            exec(resolve, reject, PLUGIN_NAME, "requestTrackingAuthorization", [showInformation, title, message, buttonTitle]);
-        });
+    requestTrackingAuthorization: function(showInformation, title, message, buttonTitle, success, error) {
+        exec(success, error, PLUGIN_NAME, 'requestTrackingAuthorization', [showInformation, title, message, buttonTitle]);
     }
 };


### PR DESCRIPTION
## Description
This PR raises the version of [firebase core](https://github.com/OutSystems/cordova-outsystems-firebase-core). This new version introduces a breaking change to O11 Firebase Plugins: there's no need for google services file to be zipped, but they need to be present in the `resources` folder.

## Context
For more context, check [here](https://outsystemsrd.atlassian.net/browse/RMET-2451)

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [x] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [ ] iOS
- [x] JavaScript

## Screenshots 
When O11 wrappers update to this version, we need to update the extensibility configuration to:

```json 
"resources" : {
   "android": {
      "AndroidResource": {
        "src": "./www/google-services.json",
        "target": "app/google-services.json"
      }
    },
    "ios": {
      "IosResource": {
        "src": "./www/GoogleService-Info.plist",
        "target": "GoogleService-Info.plist"
      }
    }
 }
```

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [x] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
