### PR TITLE
RMET-2731 ::: Add E-Commerce Events Logging on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The changes documented here do not include those from the original repository.
 
 ## [Unreleased]
 
+### 2023-12-18
+- Feat: Implement e-commerce logging on iOS (https://outsystemsrd.atlassian.net/browse/RMET-2731).
+
 ### 2023-12-13
 - Feat: add new e-commerce logging method (https://outsystemsrd.atlassian.net/browse/RMET-2729).
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -38,6 +38,8 @@ xmlns:android="http://schemas.android.com/apk/res/android"
             </feature>
         </config-file>
 
+        <dependency id="cordova-plugin-add-swift-support" url="https://github.com/OutSystems/cordova-plugin-add-swift-support.git#2.0.3-OS1"/>
+
         <!--
             use a bit hacky method to set boolean value as a string:
             https://developer.apple.com/documentation/foundation/nsstring/1409420-boolvalue?preferredLanguage=occ
@@ -54,6 +56,23 @@ xmlns:android="http://schemas.android.com/apk/res/android"
 
         <header-file src="src/ios/FirebaseAnalyticsPlugin.h" />
         <source-file src="src/ios/FirebaseAnalyticsPlugin.m" />
+
+        <source-file src="src/ios/Common/Extensions/StringConvertable.swift" target-dir="Common/Extensions" />
+        <source-file src="src/ios/Common/OSFANLError.swift" target-dir="Common" />
+        <source-file src="src/ios/Common/OSFANLGlobalValues.swift" target-dir="Common" />
+        <source-file src="src/ios/Common/OSFANLInputDataFieldKey.swift" target-dir="Common" />
+
+        <source-file src="src/ios/InputTransformer/OSFANLInputTransformable.swift" target-dir="InputTransformer" />
+        <source-file src="src/ios/InputTransformer/OSFANLInputTransformableModel.swift" target-dir="InputTransformer" />
+        <source-file src="src/ios/InputTransformer/OSFANLInputTransformer.swift" target-dir="InputTransformer" />
+
+        <source-file src="src/ios/Manager/OSFANLManageable.swift" target-dir="Manager" />
+        <source-file src="src/ios/Manager/OSFANLManager.swift" target-dir="Manager" />
+        <source-file src="src/ios/Manager/OSFANLManager+EventValidationRules.swift" target-dir="Manager" />
+        <source-file src="src/ios/Manager/OSFANLManagerFactory.swift" target-dir="Manager" />
+        <source-file src="src/ios/Manager/OSFANLOutputModel.swift" target-dir="Manager" />
+
+        <source-file src="src/ios/Validator/OSFANLEventValidator.swift" target-dir="Validator" />
 
         <podspec>
             <config>

--- a/src/ios/Common/Extensions/StringConvertable.swift
+++ b/src/ios/Common/Extensions/StringConvertable.swift
@@ -1,0 +1,20 @@
+protocol StringConvertable {
+    static var variableType: String { get }
+    init?(value: String)
+}
+
+extension Decimal: StringConvertable {
+    static var variableType: String { "Decimal" }
+    
+    init?(value: String) {
+        self.init(string: value)
+    }
+}
+
+extension String: StringConvertable {
+    static var variableType: String { "Text" }
+    
+    init?(value: String) {
+        self.init(stringLiteral: value)
+    }
+}

--- a/src/ios/Common/OSFANLError.swift
+++ b/src/ios/Common/OSFANLError.swift
@@ -1,0 +1,45 @@
+enum OSFANLError: Error {
+    case duplicateItemsIn(parameter: String)
+    case duplicateKeys
+    case invalidType(_ parameter: String, type: String)
+    case logEcommerceEventInputArgumentsIssue
+    case missing(_ parameter: String)
+    case missingItemIdName
+    case tooMany(parameter: String, limit: Int)
+    case unexpected(_ event: String)
+}
+
+extension OSFANLError: CustomNSError {
+    var errorCode: Int {
+        switch self {
+        case .duplicateItemsIn(_): return 1
+        case .duplicateKeys: return 2
+        case .invalidType(_, _): return 3
+        case .logEcommerceEventInputArgumentsIssue: return 4
+        case .missing(_): return 5
+        case .missingItemIdName: return 6
+        case .tooMany(_, _): return 7
+        case .unexpected(_): return 8
+        }
+    }
+    
+    var errorDescription: String? {
+        switch self {
+        case .duplicateItemsIn(let parameter): return "Parameter '\(parameter)' contains duplicate items."
+        case .duplicateKeys: return "The dictionary contains duplicate keys"
+        case .invalidType(let parameter, let type): return "Parameter '\(parameter)' must be of type '\(type)'"
+        case .logEcommerceEventInputArgumentsIssue: return "There's an issue with the `logECommerceEvent` input arguments."
+        case .missing(let parameter): return "Required parameter '\(parameter)' is missing."
+        case .missingItemIdName: return "Item requires an ID or a Name."
+        case .tooMany(let parameter, let limit): return "Parameter '\(parameter)' must be set to a maximum number of \(limit)."
+        case .unexpected(let event): return "Event '\(event)' is not valid."
+        }
+    }
+    
+    var errorUserInfo: [String: Any] {
+        [
+            "code"      : "OS-PLUG-FANL-\(String(format: "%04d", self.errorCode))",
+            "message"   : self.errorDescription ?? ""
+        ]
+    }
+}

--- a/src/ios/Common/OSFANLGlobalValues.swift
+++ b/src/ios/Common/OSFANLGlobalValues.swift
@@ -1,0 +1,5 @@
+struct OSFANLDefaultValues {
+    static let itemQuantity: Int = 1
+    static let itemCustomParametersMaximum: Int = 27
+    static let eventItemsMaximum: Int = 200
+}

--- a/src/ios/Common/OSFANLInputDataFieldKey.swift
+++ b/src/ios/Common/OSFANLInputDataFieldKey.swift
@@ -1,0 +1,18 @@
+enum OSFANLInputDataFieldKey: String {
+    case customParameters = "custom_parameters"
+    case currency
+    case event
+    case eventParameters
+    case item
+    case itemId = "item_id"
+    case itemListId = "item_list_id"
+    case itemListName = "item_list_name"
+    case itemName = "item_name"
+    case items
+    case key
+    case quantity
+    case shipping
+    case tax
+    case transactionId = "transaction_id"
+    case value
+}

--- a/src/ios/FirebaseAnalyticsPlugin.h
+++ b/src/ios/FirebaseAnalyticsPlugin.h
@@ -3,6 +3,7 @@
 @interface FirebaseAnalyticsPlugin : CDVPlugin
 
 - (void)logEvent:(CDVInvokedUrlCommand*)command;
+- (void)logECommerceEvent:(CDVInvokedUrlCommand *)command;
 - (void)setUserId:(CDVInvokedUrlCommand*)command;
 - (void)setUserProperty:(CDVInvokedUrlCommand*)command;
 - (void)setEnabled:(CDVInvokedUrlCommand*)command;

--- a/src/ios/InputTransformer/OSFANLInputTransformable.swift
+++ b/src/ios/InputTransformer/OSFANLInputTransformable.swift
@@ -1,0 +1,3 @@
+protocol OSFANLInputTransformable {
+    func transform(_ eventParameterArray: [InputParameterData]?, _ itemArray: [InputItemData]?) throws -> OSFANLInputTransformableModel
+}

--- a/src/ios/InputTransformer/OSFANLInputTransformableModel.swift
+++ b/src/ios/InputTransformer/OSFANLInputTransformableModel.swift
@@ -1,0 +1,9 @@
+struct OSFANLInputTransformableModel {
+    let eventParameterData: InputParameterData?
+    var itemArray: [InputItemData]?
+    
+    init(_ eventParameterData: InputParameterData?, _ itemArray: [InputItemData]?) {
+        self.eventParameterData = eventParameterData
+        self.itemArray = itemArray
+    }
+}

--- a/src/ios/InputTransformer/OSFANLInputTransformer.swift
+++ b/src/ios/InputTransformer/OSFANLInputTransformer.swift
@@ -1,0 +1,88 @@
+struct OSFANLInputTransformer: OSFANLInputTransformable {
+    func transform(_ eventParameterArray: [InputParameterData]?, _ itemArray: [InputItemData]?) throws -> OSFANLInputTransformableModel {
+        var eventParameterData: InputParameterData?
+        if let eventParameterArray {
+            guard let flatResult = try? self.flat(keyValueMapArray: eventParameterArray) else {
+                throw OSFANLError.duplicateItemsIn(parameter: OSFANLInputDataFieldKey.eventParameters.rawValue)
+            }
+            eventParameterData = flatResult
+        }
+        let itemArray = try self.transform(itemArray)
+        
+        return .init(eventParameterData, itemArray)
+    }
+}
+
+private extension OSFANLInputTransformer {
+    func flat(keyValueMapArray array: [InputParameterData]) throws -> InputParameterData {
+        let flatKeyValueArray = array.map {
+            [$0[OSFANLInputDataFieldKey.key.rawValue, default: ""]: $0[OSFANLInputDataFieldKey.value.rawValue, default: ""]]
+        }
+        let flatKeyValueDictionary = self.flat(dictionaryArray: flatKeyValueArray)
+        
+        if flatKeyValueDictionary.count != flatKeyValueArray.count { throw OSFANLError.duplicateKeys }
+        return flatKeyValueDictionary
+    }
+    
+    func transform(_ itemArray: [InputItemData]?) throws -> [InputItemData]? {
+        // if nil or empty, just return it as there's nothing to do here.
+        guard let itemArray, !itemArray.isEmpty else {
+            return itemArray
+        }
+        // if there's more than the expected maximum, return the error
+        guard itemArray.count <= OSFANLDefaultValues.eventItemsMaximum else {
+            throw OSFANLError.tooMany(parameter: OSFANLInputDataFieldKey.items.rawValue, limit: OSFANLDefaultValues.eventItemsMaximum)
+        }
+        
+        var resultArray: [InputItemData] = []
+        for itemData in itemArray {
+            // there needs to be at least one `item_id` or `item_name`
+            guard itemData.keys.contains(where: { [OSFANLInputDataFieldKey.itemId, .itemName].map(\.rawValue).contains($0) }) else {
+                throw OSFANLError.missingItemIdName
+            }
+            
+            var resultItem: InputItemData = [:]
+            // insert quantity when missing
+            if !itemData.keys.contains(OSFANLInputDataFieldKey.quantity.rawValue) {
+                resultItem[OSFANLInputDataFieldKey.quantity.rawValue] = OSFANLDefaultValues.itemQuantity
+            }
+            
+            let customParametersSplit = Dictionary(grouping: itemData) { $0.key == OSFANLInputDataFieldKey.customParameters.rawValue }
+            if let regularParameterArray = customParametersSplit[false] { resultItem += self.flat(tupleArray: regularParameterArray) }
+            
+            if let customParameterArray = customParametersSplit[true]?.first?.value as? [InputParameterData], !customParameterArray.isEmpty {
+                // if there's more than the expected maximum, return the error
+                guard customParameterArray.count <= OSFANLDefaultValues.itemCustomParametersMaximum else {
+                    throw OSFANLError.tooMany(
+                        parameter: OSFANLInputDataFieldKey.customParameters.rawValue, limit: OSFANLDefaultValues.itemCustomParametersMaximum
+                    )
+                }
+                guard let customParameterDictionary = try? self.flat(keyValueMapArray: customParameterArray) else {
+                    throw OSFANLError.duplicateItemsIn(parameter: OSFANLInputDataFieldKey.customParameters.rawValue)
+                }
+                // check if there are repeated keys. If so, return an error.
+                if !resultItem.keys.filter({ customParameterDictionary.keys.contains($0) }).isEmpty {
+                    throw OSFANLError.duplicateItemsIn(parameter: OSFANLInputDataFieldKey.item.rawValue)
+                }
+                resultItem += customParameterDictionary
+            }
+            
+            resultArray.append(resultItem)
+        }
+        
+        return resultArray
+    }
+}
+
+private extension OSFANLInputTransformer {
+    func flat<Key, Value>(dictionaryArray: [[Key: Value]]) -> [Key: Value] {
+        dictionaryArray
+            .flatMap { $0 }
+            .reduce(into: [Key: Value]()) { $0[$1.key] = $1.value }
+    }
+    
+    func flat<Key, Value>(tupleArray: [(Key, Value)]) -> [Key: Value] {
+        tupleArray
+            .reduce(into: [Key: Value]()) { $0[$1.0] = $1.1 }
+    }
+}

--- a/src/ios/Manager/OSFANLManageable.swift
+++ b/src/ios/Manager/OSFANLManageable.swift
@@ -1,0 +1,17 @@
+typealias DefaultKeyValueData = [String: Any]
+
+extension DefaultKeyValueData {
+    static func += <K, V>(left: inout [K: V], right: [K: V]) {
+        for (key, value) in right {
+            left[key] = value
+        }
+    }
+}
+
+typealias InputParameterData = [String: String]
+typealias InputItemData = DefaultKeyValueData
+typealias OutputParameterData = DefaultKeyValueData
+
+@objc protocol OSFANLManageable {
+    func createEventModel(for inputArgument: InputParameterData) throws -> OSFANLOutputModel
+}

--- a/src/ios/Manager/OSFANLManager+EventValidationRules.swift
+++ b/src/ios/Manager/OSFANLManager+EventValidationRules.swift
@@ -1,0 +1,124 @@
+import FirebaseAnalytics
+
+typealias ValidationMethod = (InputParameterData?, inout [InputItemData]?) throws -> Void
+
+extension OSFANLManager {
+    convenience init(_ inputTransformer: OSFANLInputTransformable) {
+        let eventValidationRulesDictionary = [
+            AnalyticsEventAddPaymentInfo:   Self.validateValueCurrencyAndMultipleItemsParameters(eventData:itemsData:),
+            AnalyticsEventAddShippingInfo:  Self.validateValueCurrencyAndMultipleItemsParameters(eventData:itemsData:),
+            AnalyticsEventAddToCart:        Self.validateValueCurrencyAndMultipleItemsParameters(eventData:itemsData:),
+            AnalyticsEventAddToWishlist:    Self.validateValueCurrencyAndMultipleItemsParameters(eventData:itemsData:),
+            AnalyticsEventBeginCheckout:    Self.validateValueCurrencyAndMultipleItemsParameters(eventData:itemsData:),
+            AnalyticsEventPurchase:         Self.validatePurchaseParameters(eventData:itemsData:),
+            AnalyticsEventRefund:           Self.validateRefundParameters(eventData:itemsData:),
+            AnalyticsEventRemoveFromCart:   Self.validateValueCurrencyAndMultipleItemsParameters(eventData:itemsData:),
+            AnalyticsEventSelectItem:       Self.validateOneItemParameters(eventData:itemsData:),
+            AnalyticsEventSelectPromotion:  Self.validateSelectPromotionParameters(eventData:itemsData:),
+            AnalyticsEventViewCart:         Self.validateValueCurrencyAndMultipleItemsParameters(eventData:itemsData:),
+            AnalyticsEventViewItem:         Self.validateValueCurrencyAndMultipleItemsParameters(eventData:itemsData:),
+            AnalyticsEventViewItemList:     Self.validateViewItemListParameters(eventData:itemsData:),
+            AnalyticsEventViewPromotion:    Self.validateOneItemParameters(eventData:itemsData:)
+        ]
+        
+        let eventValidator = OSFANLEventValidator(eventValidatorMapping: eventValidationRulesDictionary)
+        self.init(inputTransformer, eventValidator)
+    }
+}
+
+private extension OSFANLManager {
+    struct ParameterToValidate: OptionSet {
+        let rawValue: Int
+        
+        static let currency         = Self(rawValue: 1 << 0)    // required if value is set
+        static let shipping         = Self(rawValue: 1 << 1)    // always optional
+        static let tax              = Self(rawValue: 1 << 2)    // always optional
+        static let transactionId    = Self(rawValue: 1 << 3)    // always required
+        static let value            = Self(rawValue: 1 << 4)    // optional
+        
+        static let currencyAndValue: Self = [.currency, .value]
+    }
+
+    enum ItemsRequired {
+        case none
+        case one
+        case atLeastOne
+    }
+    
+    static func validate(_ eventData: InputParameterData?, _ itemsData: inout [InputItemData]?, parameters: ParameterToValidate? = nil, itemsRequired: ItemsRequired) throws {
+        // Validate parameters first
+        if let parameters {
+            if parameters.contains(.currencyAndValue) {
+                let valueContainsValue = try self.validate(parameter: OSFANLInputDataFieldKey.value.rawValue, ofType: Decimal.self, eventData)
+                try self.validate(
+                    parameter: OSFANLInputDataFieldKey.currency.rawValue, ofType: String.self, isRequired: valueContainsValue, eventData
+                )
+            }
+            if parameters.contains(.transactionId) {
+                try self.validate(parameter: OSFANLInputDataFieldKey.transactionId.rawValue, ofType: String.self, isRequired: true, eventData)
+            }
+            if parameters.contains(.shipping) {
+                try self.validate(parameter: OSFANLInputDataFieldKey.shipping.rawValue, ofType: Decimal.self, eventData)
+            }
+            if parameters.contains(.tax) {
+                try self.validate(parameter: OSFANLInputDataFieldKey.tax.rawValue, ofType: Decimal.self, eventData)
+            }
+        }
+        
+        if itemsRequired != .none, itemsData?.count ?? 0 < 1 { throw OSFANLError.missing(OSFANLInputDataFieldKey.items.rawValue) }
+        
+        if case .one = itemsRequired, let nonNilItemsData = itemsData, nonNilItemsData.count > 1 {
+            itemsData?.removeLast(nonNilItemsData.count - 1)
+        }
+        
+        if let eventData {
+            let itemListKey: [String] = [OSFANLInputDataFieldKey.itemListId, .itemListName].map(\.rawValue)
+            
+            if eventData.keys.contains(where: { itemListKey.contains($0) }) {
+                if let nonNilItemsData = itemsData {
+                    for (index, itemData) in nonNilItemsData.enumerated() where itemData.keys.contains(where: { itemListKey.contains($0) }) {
+                        itemsData?[index][OSFANLInputDataFieldKey.itemListId.rawValue] = nil
+                        itemsData?[index][OSFANLInputDataFieldKey.itemListName.rawValue] = nil
+                    }
+                }
+            }
+        }
+    }
+    
+    private static func validateValueCurrencyAndMultipleItemsParameters(eventData: InputParameterData?, itemsData: inout [InputItemData]?) throws {
+        try self.validate(eventData, &itemsData, parameters: .currencyAndValue, itemsRequired: .atLeastOne)
+    }
+    
+    private static func validatePurchaseParameters(eventData: InputParameterData?, itemsData: inout [InputItemData]?) throws {
+        try self.validate(eventData, &itemsData, parameters: [.currencyAndValue, .transactionId, .shipping, .tax], itemsRequired: .atLeastOne)
+    }
+    
+    private static func validateRefundParameters(eventData: InputParameterData?, itemsData: inout [InputItemData]?) throws {
+        try self.validate(eventData, &itemsData, parameters: [.currencyAndValue, .transactionId, .shipping, .tax], itemsRequired: .none)
+    }
+    
+    private static func validateOneItemParameters(eventData: InputParameterData?, itemsData: inout [InputItemData]?) throws {
+        try self.validate(eventData, &itemsData, itemsRequired: .one)
+    }
+    
+    private static func validateSelectPromotionParameters(eventData: InputParameterData?, itemsData: inout [InputItemData]?) throws {
+        try self.validate(eventData, &itemsData, itemsRequired: .none)
+    }
+    
+    private static func validateViewItemListParameters(eventData: InputParameterData?, itemsData: inout [InputItemData]?) throws {
+        try self.validate(eventData, &itemsData, itemsRequired: .atLeastOne)
+    }
+    
+    @discardableResult
+    private static func validate<T: CustomStringConvertible & StringConvertable>(parameter: String, ofType type: T.Type, isRequired: Bool = false, _ eventData: InputParameterData?) throws -> Bool {
+        func espace(_ isRequired: Bool, parameterMissing parameter: String) throws -> Bool {
+            if isRequired { throw OSFANLError.missing(parameter) }
+            return false // indicates that there's no value associated to `parameter`
+        }
+        
+        guard let eventData, !eventData.isEmpty else { return try espace(isRequired, parameterMissing: "eventParameters") }
+        guard let parameterStringValue = eventData[parameter] else { return try espace(isRequired, parameterMissing: parameter) }
+        if T(value: parameterStringValue) == nil { throw OSFANLError.invalidType(parameter, type: T.variableType) }
+        return true // indicates that there's a value associated to `parameter`
+    }
+}

--- a/src/ios/Manager/OSFANLManager.swift
+++ b/src/ios/Manager/OSFANLManager.swift
@@ -1,0 +1,42 @@
+class OSFANLManager {
+    private let inputTransformer: OSFANLInputTransformable
+    private let eventValidator: OSFANLEventValidator
+    
+    init(_ inputTransformer: OSFANLInputTransformable, _ eventValidator: OSFANLEventValidator) {
+        self.inputTransformer = inputTransformer
+        self.eventValidator = eventValidator
+    }
+}
+
+extension OSFANLManager: OSFANLManageable {
+    private func convert<T>(jsonString: String) -> T? {
+        guard let jsonData = jsonString.data(using: .utf8) else { return nil }
+        return try? JSONSerialization.jsonObject(with: jsonData, options: .fragmentsAllowed) as? T
+    }
+    
+    func createEventModel(for inputArgument: InputParameterData) throws -> OSFANLOutputModel {
+        guard let eventName = inputArgument[OSFANLInputDataFieldKey.event.rawValue], !eventName.isEmpty else {
+            throw OSFANLError.missing(OSFANLInputDataFieldKey.event.rawValue)
+        }
+        
+        var eventParameterArray: [InputParameterData]?
+        if let eventParameterString = inputArgument[OSFANLInputDataFieldKey.eventParameters.rawValue] {
+            eventParameterArray = self.convert(jsonString: eventParameterString)
+        }
+        
+        var itemArray: [InputItemData]?
+        if let itemString = inputArgument[OSFANLInputDataFieldKey.items.rawValue] {
+            itemArray = self.convert(jsonString: itemString)
+        }
+        
+        var inputModel = try self.inputTransformer.transform(eventParameterArray, itemArray)
+        try self.eventValidator.validate(event: eventName, inputModel.eventParameterData, &inputModel.itemArray)
+        
+        var outputModelParameterData: OutputParameterData = inputModel.eventParameterData ?? [:]
+        if let inputModelItemArray = inputModel.itemArray, !inputModelItemArray.isEmpty {
+            outputModelParameterData += [OSFANLInputDataFieldKey.items.rawValue: inputModelItemArray]
+        }
+        
+        return .init(eventName, outputModelParameterData)
+    }
+}

--- a/src/ios/Manager/OSFANLManagerFactory.swift
+++ b/src/ios/Manager/OSFANLManagerFactory.swift
@@ -1,0 +1,7 @@
+@objc class OSFANLManagerFactory: NSObject {
+    @objc static func createManager() -> OSFANLManageable {
+        let inputTransformer = OSFANLInputTransformer()
+        
+        return OSFANLManager(inputTransformer)
+    }
+}

--- a/src/ios/Manager/OSFANLOutputModel.swift
+++ b/src/ios/Manager/OSFANLOutputModel.swift
@@ -1,0 +1,9 @@
+@objc class OSFANLOutputModel: NSObject {
+    @objc let name: String
+    @objc let parameters: [String: Any]
+    
+    init(_ name: String, _ parameters: [String: Any]) {
+        self.name = name
+        self.parameters = parameters
+    }
+}

--- a/src/ios/Validator/OSFANLEventValidator.swift
+++ b/src/ios/Validator/OSFANLEventValidator.swift
@@ -1,0 +1,12 @@
+struct OSFANLEventValidator {
+    private let eventValidatorMapping: [String: ValidationMethod]
+    
+    init(eventValidatorMapping: [String: ValidationMethod]) {
+        self.eventValidatorMapping = eventValidatorMapping
+    }
+    
+    func validate(event: String, _ eventParameterData: InputParameterData?, _ itemArray: inout [InputItemData]?) throws {
+        guard let eventValidation = self.eventValidatorMapping[event] else { throw OSFANLError.unexpected(event) }
+        try eventValidation(eventParameterData, &itemArray)
+    }
+}


### PR DESCRIPTION
## Description
Implement the logic required to perform e-commerce event logging. The implementation is similar to the already existing logEvent but without any parameter number constraints.

Before logging, and considering that the Firebase Analytics library doesn't return any kind of error in case of any issues with the data, the implementation performs the following steps: 
1. Flat the Key-Value pair information to a JSON Object. This is done on both Event Parameters and Items. 
2. Validate if the event parameters and items are correctly constructed. Both validations are done isolated, with errors being handled and returned in case of occurrence. 
3. Validate the event parameters and items are valid according to the event name. This time, the validation is done altogether, with errors being handled and returned in case of occurrence. 
4. Merge event parameters and items into a single JSON object to be sent to Analytics for logging purposes.

The implementation, since it's done using Swift, involves adding the Swift dependency to the `plugin.xml`.

## Context
https://outsystemsrd.atlassian.net/browse/RMET-2731

## Type of changes
- [ ] Fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [x] iOS
- [ ] JavaScript

## Tests
There's a new screen on the `Firebase Sample App` with all the tests performed on the code. The screen is available on: "Analytics > Open Ecommerce Events Screen". The button colour indicates the successful/error expected state of the test.

![IMG_0065](https://github.com/OutSystems/cordova-plugin-firebase-analytics/assets/97543217/4fdecd1e-bcaf-4bd3-858e-efd98d806501)
![IMG_0066](https://github.com/OutSystems/cordova-plugin-firebase-analytics/assets/97543217/1bc38929-04e3-4dc3-9d1e-861eb232be64)
![IMG_0067](https://github.com/OutSystems/cordova-plugin-firebase-analytics/assets/97543217/3c17ddbe-d0bc-4971-af2f-ed9f162fb633)

## Checklist
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [x] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
