### PR TITLE
RMET-3274 ::: iOS ::: Update 3rd Party that Adds Privacy Manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The changes documented here do not include those from the original repository.
 
 ## [Unreleased]
+
+### 2024-03-21
+- Chore: Update `FirebaseAnalytics` iOS pod to version `10.23.0` (https://outsystemsrd.atlassian.net/browse/RMET-3274).
+
 ### 2024-01-30
-- Chore: Update Firebase/Analytics pod to version 8.15.0. (https://outsystemsrd.atlassian.net/browse/RMET-3140)
+- Chore: Update`Firebase/Analytics` iOS pod to version `8.15.0` (https://outsystemsrd.atlassian.net/browse/RMET-3140).
 
 ## 5.0.0-OS11
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -27,7 +27,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
     <dependency id="cordova-outsystems-firebase-core" url="https://github.com/OutSystems/cordova-outsystems-firebase-core.git#2.0.0"/>
 
     <platform name="ios">
-        <preference name="IOS_FIREBASE_ANALYTICS_VERSION" default="8.15.0"/>
+        <preference name="IOS_FIREBASE_ANALYTICS_VERSION" default="10.23.0"/>
 
         <hook type="after_prepare" src="hooks/ios/iOSCopyPreferences.js" />
 
@@ -78,8 +78,8 @@ xmlns:android="http://schemas.android.com/apk/res/android"
             <config>
                 <source url="https://cdn.cocoapods.org/"/>
             </config>
-            <pods>
-                <pod name="Firebase/Analytics" spec="$IOS_FIREBASE_ANALYTICS_VERSION" />
+            <pods use-frameworks="true">
+                <pod name="FirebaseAnalytics" spec="$IOS_FIREBASE_ANALYTICS_VERSION" />
             </pods>
         </podspec>
 

--- a/src/ios/FirebaseAnalyticsPlugin.m
+++ b/src/ios/FirebaseAnalyticsPlugin.m
@@ -1,8 +1,9 @@
 #import "FirebaseAnalyticsPlugin.h"
 #import "OutSystems-Swift.h"
 
-@import Firebase;
 @import AppTrackingTransparency;
+@import FirebaseAnalytics;
+@import FirebaseCore;
 
 @interface FirebaseAnalyticsPlugin ()
 


### PR DESCRIPTION
## Description
- Update 3rd party SDK version to `10.23.0`.
- Enable the `use_frameworks` flag for CocoaPods.
- Fix import errors.

## Context
https://outsystemsrd.atlassian.net/browse/RMET-3274

## Type of changes
- [ ] Fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [x] iOS
- [ ] JavaScript

## Tests
Manual testing was performed and all were successful.

## Firebase Sample App Privacy Report
[Firebase.Sample.App-PrivacyReport.pdf](https://github.com/OutSystems/cordova-plugin-firebase-analytics/files/14720480/Firebase.Sample.App-PrivacyReport.pdf)

## Checklist
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
