### PR TITLE
RMET-3503 ::: Make `ANALYTICS_COLLECTION_ENABLED` Configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The changes documented here do not include those from the original repository.
 
+## [Unreleased]
+- Fix: Make `ANALYTICS_COLLECTION_ENABLED` configurable (https://outsystemsrd.atlassian.net/browse/RMET-3503).
+
 ## 5.0.0-OS12
 - Chore: Update `FirebaseAnalytics` iOS pod to version `10.23.0` (https://outsystemsrd.atlassian.net/browse/RMET-3274).
 

--- a/hooks/android/androidCopyPreferences.js
+++ b/hooks/android/androidCopyPreferences.js
@@ -1,0 +1,24 @@
+const path = require('path');
+const fs = require('fs');
+const { ConfigParser } = require('cordova-common');
+const { DOMParser, XMLSerializer } = require('@xmldom/xmldom')
+
+module.exports = function (context) {
+    var projectRoot = context.opts.cordova.project ? context.opts.cordova.project.root : context.opts.projectRoot;
+    var configXML = path.join(projectRoot, 'config.xml');
+    var configParser = new ConfigParser(configXML);
+    
+    var manifestPath = path.join(projectRoot, 'platforms/android/app/src/main/AndroidManifest.xml');
+
+    const doc = new DOMParser().parseFromString(fs.readFileSync(manifestPath, 'utf8'), 'text/xml');
+
+    var collectionEnabled = configParser.getGlobalPreference("ANALYTICS_COLLECTION_ENABLED");    
+    if (collectionEnabled.toLowerCase() == 'false') {
+        var applicationData = doc.getElementsByTagName('application');
+        var newElement = doc.createElement("meta-data android:name=\"firebase_analytics_collection_enabled\" android:value=\""+ collectionEnabled + "\"");        
+        applicationData.item(0).appendChild(newElement);
+    } 
+
+    const serialized = new XMLSerializer().serializeToString(doc);
+    fs.writeFileSync(manifestPath, serialized);
+};

--- a/hooks/android/androidCopyPreferences.js
+++ b/hooks/android/androidCopyPreferences.js
@@ -1,24 +1,45 @@
 const path = require('path');
 const fs = require('fs');
 const { ConfigParser } = require('cordova-common');
-const { DOMParser, XMLSerializer } = require('@xmldom/xmldom')
+const xml2js = require('xml2js');
+const q = require('q');
 
 module.exports = function (context) {
-    var projectRoot = context.opts.cordova.project ? context.opts.cordova.project.root : context.opts.projectRoot;
-    var configXML = path.join(projectRoot, 'config.xml');
-    var configParser = new ConfigParser(configXML);
+    let projectRoot = context.opts.cordova.project ? context.opts.cordova.project.root : context.opts.projectRoot;
+    let configXML = path.join(projectRoot, 'config.xml');
+    let configParser = new ConfigParser(configXML);
     
-    var manifestPath = path.join(projectRoot, 'platforms/android/app/src/main/AndroidManifest.xml');
+    let manifestPath = path.join(projectRoot, 'platforms/android/app/src/main/AndroidManifest.xml');
 
-    const doc = new DOMParser().parseFromString(fs.readFileSync(manifestPath, 'utf8'), 'text/xml');
+    let defer = q.defer();
 
-    var collectionEnabled = configParser.getGlobalPreference("ANALYTICS_COLLECTION_ENABLED");    
+    let collectionEnabled = configParser.getGlobalPreference("ANALYTICS_COLLECTION_ENABLED");    
     if (collectionEnabled.toLowerCase() == 'false') {
-        var applicationData = doc.getElementsByTagName('application');
-        var newElement = doc.createElement("meta-data android:name=\"firebase_analytics_collection_enabled\" android:value=\""+ collectionEnabled + "\"");        
-        applicationData.item(0).appendChild(newElement);
-    } 
+        let parser = new xml2js.Parser();
+        parser.parseStringPromise(fs.readFileSync(manifestPath, 'utf8')).then((result) => {
+            let metadata = result.manifest.application[0]['meta-data'];
+            metadata.push({
+                '$': {
+                    'android:name': 'firebase_analytics_collection_enabled',
+                    'android:value': 'false'
+                }
+            })
 
-    const serialized = new XMLSerializer().serializeToString(doc);
-    fs.writeFileSync(manifestPath, serialized);
+            let builder = new xml2js.Builder();
+            let xml = builder.buildObject(result);
+
+            fs.writeFileSync(manifestPath, xml, (err) => {
+                throw new Error (`OUTSYSTEMS_PLUGIN_ERROR: Something went wrong while saving the AndroidManifest.xml file. Please check the logs for more information.`);
+            });
+
+            defer.resolve();
+        })
+        .catch((err) => {
+            throw new Error (`OUTSYSTEMS_PLUGIN_ERROR: Something went wrong while parsing the AndroidManifest.xml file. Please check the logs for more information.`);
+        });
+    } else {
+        defer.resolve();
+    }
+
+    return defer.promise;
 };

--- a/hooks/ios/iOSCopyPreferences.js
+++ b/hooks/ios/iOSCopyPreferences.js
@@ -17,12 +17,10 @@ module.exports = function (context) {
         let userTrackingDescription = configParser.getPlatformPreference("USER_TRACKING_DESCRIPTION_IOS", "ios");
         if(userTrackingDescription != ""){
             obj['NSUserTrackingUsageDescription'] = userTrackingDescription;
-            fs.writeFileSync(infoPlistPath, plist.build(obj));
         }
     }
     else if(enableAppTracking == "false"){
-        delete obj['NSUserTrackingUsageDescription'];
-        fs.writeFileSync(infoPlistPath, plist.build(obj));
+        delete obj['NSUserTrackingUsageDescription'];        
     }
 
     let collectionEnabled = configParser.getGlobalPreference("ANALYTICS_COLLECTION_ENABLED");

--- a/hooks/ios/iOSCopyPreferences.js
+++ b/hooks/ios/iOSCopyPreferences.js
@@ -4,17 +4,17 @@ const plist = require('plist');
 const { ConfigParser } = require('cordova-common');
 
 module.exports = function (context) {
-    var projectRoot = context.opts.cordova.project ? context.opts.cordova.project.root : context.opts.projectRoot;
-    var configXML = path.join(projectRoot, 'config.xml');
-    var configParser = new ConfigParser(configXML);
+    let projectRoot = context.opts.cordova.project ? context.opts.cordova.project.root : context.opts.projectRoot;
+    let configXML = path.join(projectRoot, 'config.xml');
+    let configParser = new ConfigParser(configXML);
     
-    var appName = configParser.name();
-    var infoPlistPath = path.join(projectRoot, 'platforms/ios/' + appName + '/'+ appName +'-info.plist');
-    var obj = plist.parse(fs.readFileSync(infoPlistPath, 'utf8'));
+    let appName = configParser.name();
+    let infoPlistPath = path.join(projectRoot, 'platforms/ios/' + appName + '/'+ appName +'-info.plist');
+    let obj = plist.parse(fs.readFileSync(infoPlistPath, 'utf8'));
 
-    var enableAppTracking = configParser.getPlatformPreference("EnableAppTrackingTransparencyPrompt", "ios");
+    let enableAppTracking = configParser.getPlatformPreference("EnableAppTrackingTransparencyPrompt", "ios");
     if(enableAppTracking == "true" || enableAppTracking == ""){
-        var userTrackingDescription = configParser.getPlatformPreference("USER_TRACKING_DESCRIPTION_IOS", "ios");
+        let userTrackingDescription = configParser.getPlatformPreference("USER_TRACKING_DESCRIPTION_IOS", "ios");
         if(userTrackingDescription != ""){
             obj['NSUserTrackingUsageDescription'] = userTrackingDescription;
             fs.writeFileSync(infoPlistPath, plist.build(obj));
@@ -25,7 +25,7 @@ module.exports = function (context) {
         fs.writeFileSync(infoPlistPath, plist.build(obj));
     }
 
-    var collectionEnabled = configParser.getGlobalPreference("ANALYTICS_COLLECTION_ENABLED");
+    let collectionEnabled = configParser.getGlobalPreference("ANALYTICS_COLLECTION_ENABLED");
     if (collectionEnabled.toLowerCase() == 'false') {
         obj['FIREBASE_ANALYTICS_COLLECTION_ENABLED'] = false;
     } 

--- a/hooks/ios/iOSCopyPreferences.js
+++ b/hooks/ios/iOSCopyPreferences.js
@@ -7,14 +7,12 @@ module.exports = function (context) {
     var projectRoot = context.opts.cordova.project ? context.opts.cordova.project.root : context.opts.projectRoot;
     var configXML = path.join(projectRoot, 'config.xml');
     var configParser = new ConfigParser(configXML);
-    var enableAppTracking = configParser.getPlatformPreference("EnableAppTrackingTransparencyPrompt", "ios");
-
-    var appNamePath = path.join(projectRoot, 'config.xml');
-    var appNameParser = new ConfigParser(appNamePath);
-    var appName = appNameParser.name();
+    
+    var appName = configParser.name();
     var infoPlistPath = path.join(projectRoot, 'platforms/ios/' + appName + '/'+ appName +'-info.plist');
     var obj = plist.parse(fs.readFileSync(infoPlistPath, 'utf8'));
 
+    var enableAppTracking = configParser.getPlatformPreference("EnableAppTrackingTransparencyPrompt", "ios");
     if(enableAppTracking == "true" || enableAppTracking == ""){
         var userTrackingDescription = configParser.getPlatformPreference("USER_TRACKING_DESCRIPTION_IOS", "ios");
         if(userTrackingDescription != ""){
@@ -26,4 +24,11 @@ module.exports = function (context) {
         delete obj['NSUserTrackingUsageDescription'];
         fs.writeFileSync(infoPlistPath, plist.build(obj));
     }
+
+    var collectionEnabled = configParser.getGlobalPreference("ANALYTICS_COLLECTION_ENABLED");
+    if (collectionEnabled.toLowerCase() == 'false') {
+        obj['FIREBASE_ANALYTICS_COLLECTION_ENABLED'] = false;
+    } 
+
+    fs.writeFileSync(infoPlistPath, plist.build(obj));
 };

--- a/plugin.xml
+++ b/plugin.xml
@@ -20,7 +20,6 @@ xmlns:android="http://schemas.android.com/apk/res/android"
         <engine name="cordova-ios" version=">=5.1.1"/>
     </engines>
 
-    <preference name="ANALYTICS_COLLECTION_ENABLED" default="true" />
     <preference name="AUTOMATIC_SCREEN_REPORTING_ENABLED" default="true" />
     <preference name="USER_TRACKING_DESCRIPTION_IOS" default="$(PRODUCT_NAME) needs your attention." />
 
@@ -85,11 +84,12 @@ xmlns:android="http://schemas.android.com/apk/res/android"
     <platform name="android">
         <preference name="ANDROID_FIREBASE_ANALYTICS_VERSION" default="21.1.1"/>
 
+        <hook type="after_prepare" src="hooks/android/androidCopyPreferences.js" />
 
         <config-file target="res/xml/config.xml" parent="/*">
             <feature name="FirebaseAnalytics">
                 <param name="android-package" value="com.outsystems.plugins.firebase.analytics.FirebaseAnalyticsPlugin" />
-                <param name="onload" value="$ANALYTICS_COLLECTION_ENABLED" />
+                <param name="onload" value="true" />
             </feature>
         </config-file>
 
@@ -98,7 +98,6 @@ xmlns:android="http://schemas.android.com/apk/res/android"
         </config-file>
 
         <config-file target="AndroidManifest.xml" parent="/manifest/application">
-            <meta-data android:name="firebase_analytics_collection_enabled" android:value="$ANALYTICS_COLLECTION_ENABLED" />
             <meta-data android:name="google_analytics_automatic_screen_reporting_enabled" android:value="$AUTOMATIC_SCREEN_REPORTING_ENABLED" />
         </config-file>
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -34,7 +34,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
         <config-file target="config.xml" parent="/*">
             <feature name="FirebaseAnalytics">
                 <param name="ios-package" value="FirebaseAnalyticsPlugin" />
-                <param name="onload" value="$ANALYTICS_COLLECTION_ENABLED" />
+                <param name="onload" value="true" />
             </feature>
         </config-file>
 
@@ -44,9 +44,6 @@ xmlns:android="http://schemas.android.com/apk/res/android"
             use a bit hacky method to set boolean value as a string:
             https://developer.apple.com/documentation/foundation/nsstring/1409420-boolvalue?preferredLanguage=occ
         -->
-        <config-file target="*-Info.plist" parent="FIREBASE_ANALYTICS_COLLECTION_ENABLED">
-            <string>$ANALYTICS_COLLECTION_ENABLED</string>
-        </config-file>
         <config-file target="*-Info.plist" parent="FirebaseAutomaticScreenReportingEnabled">
             <string>$AUTOMATIC_SCREEN_REPORTING_ENABLED</string>
         </config-file>


### PR DESCRIPTION
## Description
- Aligned with our interpretation of [Firebase's recommendations](https://firebase.google.com/docs/analytics/configure-data-collection?platform=android#disable_data_collection), this property is just added when it's explicitly set to `false`.
- Change the "onload" property to yes, as plugin variables aren't an option with OutSystems. As before, the plugin is initialised when the app is, independently of the preference configuration.

## Context
https://outsystemsrd.atlassian.net/browse/RMET-3503

## Type of changes
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [x] iOS
- [ ] JavaScript

## Tests
Manual testing was performed, including the different options for the preference:
- No value
- `true` value
- `false` value

## Checklist
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [x] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
