### PR TITLE
RMET-3677 & RMET-3678 - Add setConsent functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The changes documented here do not include those from the original repository.
 
+## 5.0.0-OS15
+
+- Feat(Android & iOS): Add setConsent functionality to allow users to set consent for analytics (https://outsystemsrd.atlassian.net/browse/RMET-3677 & https://outsystemsrd.atlassian.net/browse/RMET-3678).
+
 ## 5.0.0-OS14
 
 - Android | Update dependency to Firebase Analytics Android library (https://outsystemsrd.atlassian.net/browse/RMET-3608).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The changes documented here do not include those from the original repository.
 
+## Unreleased
+- Android | Update dependency to Firebase Analytics Android library (https://outsystemsrd.atlassian.net/browse/RMET-3608).
+
 ## 5.0.0-OS13
 - Fix: Make `ANALYTICS_COLLECTION_ENABLED` configurable (https://outsystemsrd.atlassian.net/browse/RMET-3503).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The changes documented here do not include those from the original repository.
 
-## Unreleased
+## 5.0.0-OS14
+
 - Android | Update dependency to Firebase Analytics Android library (https://outsystemsrd.atlassian.net/browse/RMET-3608).
 
 ## 5.0.0-OS13
+
 - Fix: Make `ANALYTICS_COLLECTION_ENABLED` configurable (https://outsystemsrd.atlassian.net/browse/RMET-3503).
 
 ## 5.0.0-OS12
+
 - Chore: Update `FirebaseAnalytics` iOS pod to version `10.23.0` (https://outsystemsrd.atlassian.net/browse/RMET-3274).
 
 ## 5.0.0-OS11

--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,11 @@ buildscript {
     }
 }
 
+dependencies {
+    implementation platform('com.google.firebase:firebase-bom:33.2.0')
+    implementation("com.google.firebase:firebase-analytics")
+}
+
 // use postBuildExtras to make sure the plugin is applied after
 // cdvPluginPostBuildExtras. Therefore if googleServices is added
 // to cdvPluginPostBuildExtras somewhere else, the plugin execution

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-firebase-analytics",
-  "version": "5.0.0-OS13",
+  "version": "5.0.0-OS14",
   "description": "Cordova plugin for Firebase Analytics",
   "cordova": {
     "id": "cordova-plugin-firebase-analytics",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-firebase-analytics",
-  "version": "5.0.0-OS14",
+  "version": "5.0.0-OS15",
   "description": "Cordova plugin for Firebase Analytics",
   "cordova": {
     "id": "cordova-plugin-firebase-analytics",

--- a/plugin.xml
+++ b/plugin.xml
@@ -82,7 +82,6 @@ xmlns:android="http://schemas.android.com/apk/res/android"
     </platform>
 
     <platform name="android">
-        <preference name="ANDROID_FIREBASE_ANALYTICS_VERSION" default="21.1.1"/>
 
         <hook type="after_prepare" src="hooks/android/androidCopyPreferences.js" />
 
@@ -103,7 +102,6 @@ xmlns:android="http://schemas.android.com/apk/res/android"
 
         <dependency id="cordova-support-android-plugin" version="~1.0.0"/>
 
-        <framework src="com.google.firebase:firebase-analytics:$ANDROID_FIREBASE_ANALYTICS_VERSION" />
         <framework src="build.gradle" custom="true" type="gradleReference" />
 
         <source-file src="src/android/com/outsystems/firebase/analytics/FirebaseAnalyticsPlugin.java" target-dir="src/com/outsystems/plugins/firebase/analytics/" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -57,6 +57,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
         <source-file src="src/ios/Common/OSFANLDefaultValues.swift" target-dir="Common" />
         <source-file src="src/ios/Common/OSFANLError.swift" target-dir="Common" />
         <source-file src="src/ios/Common/OSFANLInputDataFieldKey.swift" target-dir="Common" />
+        <source-file src="src/ios/Common/OSFANLConsentHelper.swift" target-dir="Common" />
 
         <source-file src="src/ios/InputTransformer/OSFANLInputTransformable.swift" target-dir="InputTransformer" />
         <source-file src="src/ios/InputTransformer/OSFANLInputTransformableModel.swift" target-dir="InputTransformer" />
@@ -108,6 +109,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
         <source-file src="src/android/com/outsystems/firebase/analytics/model/OSFANLBundle+putAny.kt" target-dir="app/src/main/kotlin/com/outsystems/firebase/analytics/model/" />
         <source-file src="src/android/com/outsystems/firebase/analytics/model/OSFANLJSONArray+extension.kt" target-dir="app/src/main/kotlin/com/outsystems/firebase/analytics/model/" />
         <source-file src="src/android/com/outsystems/firebase/analytics/model/OSFANLDefaultValues.kt" target-dir="app/src/main/kotlin/com/outsystems/firebase/analytics/model/" />
+        <source-file src="src/android/com/outsystems/firebase/analytics/model/OSFANLConsentModels.kt" target-dir="app/src/main/kotlin/com/outsystems/firebase/analytics/model/" />
         <source-file src="src/android/com/outsystems/firebase/analytics/model/OSFANLError.kt" target-dir="app/src/main/kotlin/com/outsystems/firebase/analytics/model/" />
         <source-file src="src/android/com/outsystems/firebase/analytics/model/OSFANLEventOutputModel.kt" target-dir="app/src/main/kotlin/com/outsystems/firebase/analytics/model/" />
         <source-file src="src/android/com/outsystems/firebase/analytics/model/OSFANLInputDataFieldKey.kt" target-dir="app/src/main/kotlin/com/outsystems/firebase/analytics/model/" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
 xmlns:android="http://schemas.android.com/apk/res/android"
            id="cordova-plugin-firebase-analytics"
-      version="5.0.0-OS14">
+      version="5.0.0-OS15">
 
     <name>FirebaseAnalyticsPlugin</name>
     <description>Cordova plugin for Firebase Analytics</description>

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
 xmlns:android="http://schemas.android.com/apk/res/android"
            id="cordova-plugin-firebase-analytics"
-      version="5.0.0-OS13">
+      version="5.0.0-OS14">
 
     <name>FirebaseAnalyticsPlugin</name>
     <description>Cordova plugin for Firebase Analytics</description>

--- a/src/android/com/outsystems/firebase/analytics/model/OSFANLConsentModels.kt
+++ b/src/android/com/outsystems/firebase/analytics/model/OSFANLConsentModels.kt
@@ -1,0 +1,29 @@
+package com.outsystems.firebase.analytics.model
+
+import com.google.firebase.analytics.FirebaseAnalytics
+
+enum class ConsentType(val value: Int, val consentType: FirebaseAnalytics.ConsentType) {
+    AD_PERSONALIZATION(1, FirebaseAnalytics.ConsentType.AD_PERSONALIZATION),
+    AD_STORAGE(2, FirebaseAnalytics.ConsentType.AD_STORAGE),
+    AD_USER_DATA(3, FirebaseAnalytics.ConsentType.AD_USER_DATA),
+    ANALYTICS_STORAGE(4, FirebaseAnalytics.ConsentType.ANALYTICS_STORAGE);
+
+    companion object {
+        private val map = entries.associateBy(ConsentType::value)
+
+        @JvmStatic
+        fun fromInt(value: Int): FirebaseAnalytics.ConsentType? = map[value]?.consentType
+    }
+}
+
+enum class ConsentStatus(val value: Int, val consentStatus: FirebaseAnalytics.ConsentStatus) {
+    GRANTED(1, FirebaseAnalytics.ConsentStatus.GRANTED),
+    DENIED(2, FirebaseAnalytics.ConsentStatus.DENIED);
+
+    companion object {
+        private val map = entries.associateBy(ConsentStatus::value)
+
+        @JvmStatic
+        fun fromInt(value: Int): FirebaseAnalytics.ConsentStatus? = map[value]?.consentStatus
+    }
+}

--- a/src/ios/Common/OSFANLConsentHelper.swift
+++ b/src/ios/Common/OSFANLConsentHelper.swift
@@ -1,0 +1,96 @@
+import FirebaseAnalytics
+import FirebaseCore
+
+@objc enum ConsentTypeRawValue: Int, CustomStringConvertible, CaseIterable {
+    case adPersonalization = 1
+    case adStorage = 2
+    case adUserData = 3
+    case analyticsStorage = 4
+    
+    var description: String {
+        return switch self {
+        case .adPersonalization: "ad_personalization"
+        case .adStorage: "ad_storage"
+        case .adUserData: "ad_user_data"
+        case .analyticsStorage: "analytics_storage"
+        }
+    }
+    
+    static func allOptionsString() -> String {
+        let capitalizedDescriptions = allCases.map { $0.description.uppercased() }
+        
+        if capitalizedDescriptions.count > 1 {
+            let lastOption = capitalizedDescriptions.last!
+            let allButLast = capitalizedDescriptions.dropLast().joined(separator: ", ")
+            return "\(allButLast), or \(lastOption)"
+        } else {
+            return capitalizedDescriptions.first ?? ""
+        }
+    }
+}
+
+@objc enum ConsentStatusRawValue: Int, CustomStringConvertible, CaseIterable {
+    case granted = 1
+    case denied = 2
+    
+    var description: String {
+        return switch self {
+        case .granted: "granted"
+        case .denied: "denied"
+        }
+    }
+    
+    static func allOptionsString() -> String {
+        let capitalizedDescriptions = allCases.map { $0.description.uppercased() }
+        
+        if capitalizedDescriptions.count > 1 {
+            let lastOption = capitalizedDescriptions.last!
+            let allButLast = capitalizedDescriptions.dropLast().joined(separator: ", ")
+            return "\(allButLast), or \(lastOption)"
+        } else {
+            return capitalizedDescriptions.first ?? ""
+        }
+    }
+}
+
+@objc class OSFANLConsentHelper: NSObject {
+    @objc static func createConsentModel(_ commandArguments: NSArray) throws -> [ConsentType: ConsentStatus] {
+        guard let jsonString = commandArguments[0] as? String,
+              let jsonData = jsonString.data(using: .utf8),
+              let array = try JSONSerialization.jsonObject(with: jsonData, options: []) as? [[String: Any]] else {
+            throw OSFANLError.invalidType("ConsentSettings", type: "JSON")
+        }
+        
+        var firebaseConsentDict: [ConsentType: ConsentStatus] = [:]
+        
+        for item in array {
+            guard let typeRawValue = item["Type"] as? Int,
+                  let statusRawValue = item["Status"] as? Int else {
+                throw OSFANLError.invalidType("JSON passed Consent Type or Status", type: "Integer")
+            }
+            
+            guard let consentTypeRawValue = ConsentTypeRawValue(rawValue: typeRawValue) else {
+                throw OSFANLError.invalidType("Consent Type", type: ConsentTypeRawValue.allOptionsString())
+            }
+            
+            guard let consentStatusRawValue = ConsentStatusRawValue(rawValue: statusRawValue) else {
+                throw OSFANLError.invalidType("Consent Status", type: ConsentStatusRawValue.allOptionsString())
+            }
+            
+            let consentType = ConsentType(rawValue: String(describing: consentTypeRawValue))
+            let consentStatus = ConsentStatus(rawValue: String(describing: consentStatusRawValue))
+            
+            if firebaseConsentDict.keys.contains(consentType) {
+                throw OSFANLError.duplicateItemsIn(parameter: "ConsentSettings")
+            } else {
+                firebaseConsentDict[consentType] = consentStatus
+            }
+        }
+        
+        if firebaseConsentDict.isEmpty {
+            throw OSFANLError.missing("ConsentSettings")
+        } else {
+            return firebaseConsentDict
+        }
+    }
+}

--- a/src/ios/FirebaseAnalyticsPlugin.h
+++ b/src/ios/FirebaseAnalyticsPlugin.h
@@ -11,5 +11,6 @@
 - (void)resetAnalyticsData:(CDVInvokedUrlCommand*)command;
 - (void)setDefaultEventParameters:(CDVInvokedUrlCommand*)command;
 - (void)requestTrackingAuthorization:(CDVInvokedUrlCommand*)command;
+- (void)setConsent:(CDVInvokedUrlCommand*)command;
 
 @end

--- a/src/ios/FirebaseAnalyticsPlugin.m
+++ b/src/ios/FirebaseAnalyticsPlugin.m
@@ -143,6 +143,18 @@
     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
 
+- (void)setConsent:(CDVInvokedUrlCommand*)command
+{
+    NSError *error;
+    NSDictionary *consentModel = [OSFANLConsentHelper createConsentModel:command.arguments error:&error];
+    if (error) {
+        [self sendError:error forCallbackId:command.callbackId];
+    } else {
+        [FIRAnalytics setConsent:consentModel];
+        [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK] callbackId:command.callbackId];
+    }
+}
+
 typedef void (^showPermissionInformationPopupHandler)(UIAlertAction*);
 - (void)showPermissionInformationPopup:
 (NSString *)title :
@@ -176,6 +188,5 @@ typedef void (^showPermissionInformationPopupHandler)(UIAlertAction*);
     CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsDictionary:error.userInfo];
     [self.commandDelegate sendPluginResult:pluginResult callbackId:callbackId];
 }
-
 
 @end

--- a/www/FirebaseAnalytics.js
+++ b/www/FirebaseAnalytics.js
@@ -55,5 +55,22 @@ module.exports = {
     logECommerceEvent: function(event, eventParameters, items, success, error) {
         let args = [{event, eventParameters, items}];
         exec(success, error, PLUGIN_NAME, 'logECommerceEvent', args);
+    },
+    /**
+     * setConsent
+     *
+     * @param {string} consentSettings - A JSON string of an object containing consent settings.
+     * @param {function} [success] - Success callback function.
+     * @param {function} [error] - Error callback function.
+     *
+     * @example
+     * const consentSettings = {
+     *  AD_STORAGE: 'GRANTED',
+     *  ANALYTICS_STORAGE: 'GRANTED',
+     * };
+     * FirebaseAnalytics.setConsent(JSON.stringify(consentSettings));
+     */
+    setConsent: function (consentSettings, success, error) {
+        exec(success, error, PLUGIN_NAME, 'setConsent', [consentSettings]);
     }
 };


### PR DESCRIPTION
## Description
Adds the `setConsent` function to the Cordova wrapper to be used by the new `SetConsent` client action. This allows developers to explicitly set the user's consent status, enabling or disabling certain data collection and processing features based on whether the user has given their consent.

## Context
References: [RMET-3677](https://outsystemsrd.atlassian.net/browse/RMET-3677) & [RMET-3678](https://outsystemsrd.atlassian.net/browse/RMET-3678)

## Type of changes
- [ ] Fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [x] iOS
- [x] JavaScript

## Tests
Tested on iPhone 14 Pro Max (iOS 18) and on Pixel 4a (Android 14)

## Checklist
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly

[RMET-3677]: https://outsystemsrd.atlassian.net/browse/RMET-3677?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RMET-3678]: https://outsystemsrd.atlassian.net/browse/RMET-3678?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ