### PR TITLE
RMET-3822 Firebase Analytics - Android - Convert values to double if necessary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The changes documented here do not include those from the original repository.
 
+## Unreleased
+
+- Fix(Android): Convert values to double if necessary (https://outsystemsrd.atlassian.net/browse/RMET-3822).
+
 ## 5.0.0-OS15
 
 - Feat(Android & iOS): Add setConsent functionality to allow users to set consent for analytics (https://outsystemsrd.atlassian.net/browse/RMET-3677 & https://outsystemsrd.atlassian.net/browse/RMET-3678).

--- a/src/android/com/outsystems/firebase/analytics/validator/OSFANLEventParameterValidator.kt
+++ b/src/android/com/outsystems/firebase/analytics/validator/OSFANLEventParameterValidator.kt
@@ -1,6 +1,7 @@
 package com.outsystems.firebase.analytics.validator
 
 import android.os.Bundle
+import android.util.Log
 import com.outsystems.firebase.analytics.model.OSFANLError
 import com.outsystems.firebase.analytics.model.OSFANLInputDataFieldKey
 import com.outsystems.firebase.analytics.model.OSFANLInputDataFieldKey.CURRENCY
@@ -8,6 +9,8 @@ import com.outsystems.firebase.analytics.model.OSFANLInputDataFieldKey.EVENT_PAR
 import com.outsystems.firebase.analytics.model.OSFANLInputDataFieldKey.KEY
 import com.outsystems.firebase.analytics.model.OSFANLInputDataFieldKey.TYPE_NUMBER
 import com.outsystems.firebase.analytics.model.OSFANLInputDataFieldKey.VALUE
+import com.outsystems.firebase.analytics.model.OSFANLInputDataFieldKey.TAX
+import com.outsystems.firebase.analytics.model.OSFANLInputDataFieldKey.SHIPPING
 import com.outsystems.firebase.analytics.model.putAny
 import org.json.JSONArray
 
@@ -85,7 +88,22 @@ class OSFANLEventParameterValidator private constructor(
             hasCurrency = hasCurrency || key == CURRENCY.json
 
             parameterKeySet.add(key)
-            result.putAny(key, value)
+
+            try {
+                // value, tax, and shipping are actually decimal values, not strings
+                if (key == VALUE.json || key == TAX.json || key == SHIPPING.json) {
+                    result.putAny(key, value.toDouble()) // can throw NumberFormatException
+                } else {
+                    result.putAny(key, value)
+                }
+            } catch (e: NumberFormatException) {
+                Log.d(
+                    "OSFANLEventParameterValidator",
+                    "Tried to convert non-number to double. Exception: ${e.message}" 
+                )
+                // if conversion isn't successful, we still try to send the event
+                result.putAny(key, value)
+            }
         }
 
         // validate value / currency


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

- If the `key` of the `parameter` is "value", "tax", or "shipping", then its value should be converted to a number (double).
- This fixes errors when logging e-commerce events because the data type of the `value` was wrong (`string` instead of `number`)

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->

References: https://outsystemsrd.atlassian.net/browse/RMET-3822

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

Tested in Android 15 (Pixel 7)

MABS 10 build: https://intranet.outsystems.net/MABS_Lite/BuildDetail?id=f27bb0d835c2bbc03683f41a5573c8f5e5ffd93a&stg=dev

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
