### PR TITLE
RMET-3823 ::: iOS ::: Fix Ecommerce Decimal Values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The changes documented here do not include those from the original repository.
 
 ## Unreleased
 
-- Fix(Android): Convert values to double if necessary (https://outsystemsrd.atlassian.net/browse/RMET-3822).
+- Fix(Android & iOS): Convert values to double if necessary (https://outsystemsrd.atlassian.net/browse/RMET-3822 & https://outsystemsrd.atlassian.net/browse/RMET-3823).
 
 ## 5.0.0-OS15
 

--- a/src/ios/Common/Extensions/StringConvertable.swift
+++ b/src/ios/Common/Extensions/StringConvertable.swift
@@ -1,20 +1,11 @@
 protocol StringConvertable {
     static var variableType: String { get }
-    init?(value: String)
 }
 
 extension Decimal: StringConvertable {
     static var variableType: String { "Decimal" }
-    
-    init?(value: String) {
-        self.init(string: value)
-    }
 }
 
 extension String: StringConvertable {
     static var variableType: String { "Text" }
-    
-    init?(value: String) {
-        self.init(stringLiteral: value)
-    }
 }

--- a/src/ios/Common/OSFANLInputDataFieldKey.swift
+++ b/src/ios/Common/OSFANLInputDataFieldKey.swift
@@ -15,3 +15,7 @@ enum OSFANLInputDataFieldKey: String {
     case transactionId = "transaction_id"
     case value
 }
+
+extension OSFANLInputDataFieldKey {
+    static var decimalDataFields: [OSFANLInputDataFieldKey] { [.shipping, .tax, .value] }
+}

--- a/src/ios/Common/OSFANLInputDataFieldKey.swift
+++ b/src/ios/Common/OSFANLInputDataFieldKey.swift
@@ -17,5 +17,9 @@ enum OSFANLInputDataFieldKey: String {
 }
 
 extension OSFANLInputDataFieldKey {
-    static var decimalDataFields: [OSFANLInputDataFieldKey] { [.shipping, .tax, .value] }
+    private static var decimalDataFields: [OSFANLInputDataFieldKey] { [.shipping, .tax, .value] }
+    
+    var isDecimalType: Bool {
+        return OSFANLInputDataFieldKey.decimalDataFields.contains(self)
+    }
 }

--- a/src/ios/InputTransformer/OSFANLInputTransformer.swift
+++ b/src/ios/InputTransformer/OSFANLInputTransformer.swift
@@ -8,15 +8,26 @@ struct OSFANLInputTransformer: OSFANLInputTransformable {
             eventParameterData = flatResult
         }
         let itemArray = try self.transform(itemArray)
-        
+
         return .init(eventParameterData, itemArray)
     }
 }
 
 private extension OSFANLInputTransformer {
     func flat(keyValueMapArray array: [InputParameterData]) throws -> InputParameterData {
-        let flatKeyValueArray = array.map {
-            [$0[OSFANLInputDataFieldKey.key.rawValue, default: ""]: $0[OSFANLInputDataFieldKey.value.rawValue, default: ""]]
+        let flatKeyValueArray = array.reduce(into: [InputParameterData]()) { partialResult, current in
+            guard let dataFieldKey = current[OSFANLInputDataFieldKey.key.rawValue] as? String,
+                  let dataValue = current[OSFANLInputDataFieldKey.value.rawValue] as? String
+            else { return }
+
+            let value: StringConvertable = if let dataField = OSFANLInputDataFieldKey(rawValue: dataFieldKey),
+                                              OSFANLInputDataFieldKey.decimalDataFields.contains(dataField) {
+                Decimal(string: dataValue) ?? .zero
+            } else {
+                dataValue
+            }
+
+            partialResult.append([dataFieldKey: value])
         }
         let flatKeyValueDictionary = self.flat(dictionaryArray: flatKeyValueArray)
         

--- a/src/ios/InputTransformer/OSFANLInputTransformer.swift
+++ b/src/ios/InputTransformer/OSFANLInputTransformer.swift
@@ -1,30 +1,32 @@
 struct OSFANLInputTransformer: OSFANLInputTransformable {
     func transform(_ eventParameterArray: [InputParameterData]?, _ itemArray: [InputItemData]?) throws -> OSFANLInputTransformableModel {
-        var eventParameterData: InputParameterData?
-        if let eventParameterArray {
-            guard let flatResult = try? self.flat(keyValueMapArray: eventParameterArray) else {
-                throw OSFANLError.duplicateItemsIn(parameter: OSFANLInputDataFieldKey.eventParameters.rawValue)
+        do {
+            var eventParameterData: InputParameterData?
+            if let eventParameterArray {
+                eventParameterData = try self.flat(keyValueMapArray: eventParameterArray)
             }
-            eventParameterData = flatResult
-        }
-        let itemArray = try self.transform(itemArray)
+            let itemArray = try self.transform(itemArray)
 
-        return .init(eventParameterData, itemArray)
+            return .init(eventParameterData, itemArray)
+        } catch OSFANLError.duplicateKeys {
+            throw OSFANLError.duplicateItemsIn(parameter: OSFANLInputDataFieldKey.eventParameters.rawValue)
+        }
     }
 }
 
 private extension OSFANLInputTransformer {
     func flat(keyValueMapArray array: [InputParameterData]) throws -> InputParameterData {
-        let flatKeyValueArray = array.reduce(into: [InputParameterData]()) { partialResult, current in
+        let flatKeyValueArray = try array.reduce(into: [InputParameterData]()) { partialResult, current in
             guard let dataFieldKey = current[OSFANLInputDataFieldKey.key.rawValue] as? String,
                   let dataValue = current[OSFANLInputDataFieldKey.value.rawValue] as? String
             else { return }
 
-            let value: StringConvertable = if let dataField = OSFANLInputDataFieldKey(rawValue: dataFieldKey),
-                                              OSFANLInputDataFieldKey.decimalDataFields.contains(dataField) {
-                Decimal(string: dataValue) ?? .zero
+            let value: StringConvertable
+            if let dataField = OSFANLInputDataFieldKey(rawValue: dataFieldKey), dataField.isDecimalType {
+                guard let decimalValue = Decimal(string: dataValue) else { throw OSFANLError.invalidType(dataFieldKey, type: Decimal.variableType) }
+                value = decimalValue
             } else {
-                dataValue
+                value = dataValue
             }
 
             partialResult.append([dataFieldKey: value])

--- a/src/ios/Manager/OSFANLManageable.swift
+++ b/src/ios/Manager/OSFANLManageable.swift
@@ -8,7 +8,7 @@ extension DefaultKeyValueData {
     }
 }
 
-typealias InputParameterData = [String: String]
+typealias InputParameterData = [String: Any]
 typealias InputItemData = DefaultKeyValueData
 typealias OutputParameterData = DefaultKeyValueData
 

--- a/src/ios/Manager/OSFANLManager+EventValidationRules.swift
+++ b/src/ios/Manager/OSFANLManager+EventValidationRules.swift
@@ -49,19 +49,17 @@ private extension OSFANLManager {
         // Validate parameters first
         if let parameters {
             if parameters.contains(.currencyAndValue) {
-                let valueContainsValue = try self.validate(parameter: OSFANLInputDataFieldKey.value.rawValue, ofType: Decimal.self, eventData)
-                try self.validate(
-                    parameter: OSFANLInputDataFieldKey.currency.rawValue, ofType: String.self, isRequired: valueContainsValue, eventData
-                )
+                let valueContainsValue = try self.validate(dataField: .value, eventData)
+                try self.validate(dataField: .currency, isRequired: valueContainsValue, eventData)
             }
             if parameters.contains(.transactionId) {
-                try self.validate(parameter: OSFANLInputDataFieldKey.transactionId.rawValue, ofType: String.self, isRequired: true, eventData)
+                try self.validate(dataField: .transactionId, isRequired: true, eventData)
             }
             if parameters.contains(.shipping) {
-                try self.validate(parameter: OSFANLInputDataFieldKey.shipping.rawValue, ofType: Decimal.self, eventData)
+                try self.validate(dataField: .shipping, eventData)
             }
             if parameters.contains(.tax) {
-                try self.validate(parameter: OSFANLInputDataFieldKey.tax.rawValue, ofType: Decimal.self, eventData)
+                try self.validate(dataField: .tax, eventData)
             }
         }
         
@@ -112,15 +110,18 @@ private extension OSFANLManager {
     }
     
     @discardableResult
-    private static func validate<T: CustomStringConvertible & StringConvertable>(parameter: String, ofType type: T.Type, isRequired: Bool = false, _ eventData: InputParameterData?) throws -> Bool {
+    private static func validate(dataField: OSFANLInputDataFieldKey, isRequired: Bool = false, _ eventData: InputParameterData?) throws -> Bool {
         func espace(_ isRequired: Bool, parameterMissing parameter: String) throws -> Bool {
             if isRequired { throw OSFANLError.missing(parameter) }
             return false // indicates that there's no value associated to `parameter`
         }
         
         guard let eventData, !eventData.isEmpty else { return try espace(isRequired, parameterMissing: "eventParameters") }
-        guard let parameterStringValue = eventData[parameter] else { return try espace(isRequired, parameterMissing: parameter) }
-        if T(value: parameterStringValue) == nil { throw OSFANLError.invalidType(parameter, type: T.variableType) }
+        let parameter = dataField.rawValue
+        guard let parameterValue = eventData[parameter] else { return try espace(isRequired, parameterMissing: parameter) }
+
+        let dataField: (type: StringConvertable.Type, value: StringConvertable?) = OSFANLInputDataFieldKey.decimalDataFields.contains(dataField) ? (Decimal.self, parameterValue as? Decimal) : (String.self, parameterValue as? String)
+        if dataField.value == nil { throw OSFANLError.invalidType(parameter, type: dataField.type.variableType) }
         return true // indicates that there's a value associated to `parameter`
     }
 }

--- a/src/ios/Manager/OSFANLManager+EventValidationRules.swift
+++ b/src/ios/Manager/OSFANLManager+EventValidationRules.swift
@@ -120,7 +120,7 @@ private extension OSFANLManager {
         let parameter = dataField.rawValue
         guard let parameterValue = eventData[parameter] else { return try espace(isRequired, parameterMissing: parameter) }
 
-        let dataField: (type: StringConvertable.Type, value: StringConvertable?) = OSFANLInputDataFieldKey.decimalDataFields.contains(dataField) ? (Decimal.self, parameterValue as? Decimal) : (String.self, parameterValue as? String)
+        let dataField: (type: StringConvertable.Type, value: StringConvertable?) = dataField.isDecimalType ? (Decimal.self, parameterValue as? Decimal) : (String.self, parameterValue as? String)
         if dataField.value == nil { throw OSFANLError.invalidType(parameter, type: dataField.type.variableType) }
         return true // indicates that there's a value associated to `parameter`
     }

--- a/src/ios/Manager/OSFANLManager.swift
+++ b/src/ios/Manager/OSFANLManager.swift
@@ -15,17 +15,17 @@ extension OSFANLManager: OSFANLManageable {
     }
     
     func createEventModel(for inputArgument: InputParameterData) throws -> OSFANLOutputModel {
-        guard let eventName = inputArgument[OSFANLInputDataFieldKey.event.rawValue], !eventName.isEmpty else {
+        guard let eventName = inputArgument[OSFANLInputDataFieldKey.event.rawValue] as? String, !eventName.isEmpty else {
             throw OSFANLError.missing(OSFANLInputDataFieldKey.event.rawValue)
         }
         
         var eventParameterArray: [InputParameterData]?
-        if let eventParameterString = inputArgument[OSFANLInputDataFieldKey.eventParameters.rawValue] {
+        if let eventParameterString = inputArgument[OSFANLInputDataFieldKey.eventParameters.rawValue] as? String {
             eventParameterArray = self.convert(jsonString: eventParameterString)
         }
         
         var itemArray: [InputItemData]?
-        if let itemString = inputArgument[OSFANLInputDataFieldKey.items.rawValue] {
+        if let itemString = inputArgument[OSFANLInputDataFieldKey.items.rawValue] as? String {
             itemArray = self.convert(jsonString: itemString)
         }
         


### PR DESCRIPTION
## Description
Make `InputParameterData` accept value types besides string:
- This requires the code to validate the type being analysed.
- Considering that we want to split between the available types (Decimal and String), we declare the `OSFANLInputDataFieldKey` values that should have a Decimal value and be treated differently.
- These changes allow us to
   - refactor the code a bit, namely the `OSFANLManager`'s `validate(dataField:isRequired:eventData:)` method, making it much simpler than it was.
   - remove the now unused `StringConvertable` initialiser.

## Context
https://outsystemsrd.atlassian.net/browse/RMET-3823

## Type of changes
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [x] iOS
- [ ] JavaScript

## Tests
Manual testing was performed to validate the fix.

## Checklist
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
