### PR TITLE
RMET-4277 - Avoid duplicating entry in `AndroidManifest.xml` for MOCA builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The changes documented here do not include those from the original repository.
 
+## Unreleased
+
+### Fixes
+- [Android] Avoid duplicating entries in `AndroidManifest.xml` with hook for MOCA (https://outsystemsrd.atlassian.net/browse/RMET-4277).
+
 ## 5.0.0-OS18
 
 ### Features

--- a/hooks/android/androidCopyPreferences.js
+++ b/hooks/android/androidCopyPreferences.js
@@ -60,6 +60,7 @@ module.exports = function (context) {
                 fs.writeFileSync(manifestPath, xml);
             }
             console.log("ANALYTICS: end of parseStringPromise");
+            defer.resolve();
         })
         .catch((err) => {
             console.log("ANALYTICS: entered catch block");

--- a/hooks/android/androidCopyPreferences.js
+++ b/hooks/android/androidCopyPreferences.js
@@ -17,22 +17,39 @@ module.exports = function (context) {
     if (collectionEnabled.toLowerCase() == 'false') {
         let parser = new xml2js.Parser();
         parser.parseStringPromise(fs.readFileSync(manifestPath, 'utf8')).then((result) => {
-            let metadata = result.manifest.application[0]['meta-data'];
-            metadata.push({
-                '$': {
-                    'android:name': 'firebase_analytics_collection_enabled',
-                    'android:value': 'false'
+            const appNode = result.manifest.application[0];
+            appNode['meta-data'] = appNode['meta-data'] || [];
+            const metadata = appNode['meta-data'];
+
+            let updated = false;
+
+            // find existing entry index
+            const index = metadata.findIndex(item => 
+                item['$']?.['android:name'] === 'firebase_analytics_collection_enabled'
+            );
+
+            if (index !== -1) {
+                // entry exists, check if we should update it
+                if (metadata[index]['$']['android:value'] === 'true') {
+                    metadata[index]['$']['android:value'] = 'false';
+                    updated = true;
                 }
-            })
+            } else {
+                // entry doesn't exist, add it
+                metadata.push({
+                    '$': {
+                        'android:name': 'firebase_analytics_collection_enabled',
+                        'android:value': 'false'
+                     }
+                });
+                updated = true;
+            }
 
-            let builder = new xml2js.Builder();
-            let xml = builder.buildObject(result);
-
-            fs.writeFileSync(manifestPath, xml, (err) => {
-                throw new Error (`OUTSYSTEMS_PLUGIN_ERROR: Something went wrong while saving the AndroidManifest.xml file. Please check the logs for more information.`);
-            });
-
-            defer.resolve();
+            if (updated) {
+                const builder = new xml2js.Builder();
+                const xml = builder.buildObject(result);
+                fs.writeFileSync(manifestPath, xml);
+            }
         })
         .catch((err) => {
             throw new Error (`OUTSYSTEMS_PLUGIN_ERROR: Something went wrong while parsing the AndroidManifest.xml file. Please check the logs for more information.`);

--- a/hooks/android/androidCopyPreferences.js
+++ b/hooks/android/androidCopyPreferences.js
@@ -17,9 +17,6 @@ module.exports = function (context) {
     if (collectionEnabled.toLowerCase() == 'false') {
         let parser = new xml2js.Parser();
         parser.parseStringPromise(fs.readFileSync(manifestPath, 'utf8')).then((result) => {
-
-            console.log("ANALYTICS: inside parseStringPromise");
-
             const appNode = result.manifest.application[0];
             appNode['meta-data'] = appNode['meta-data'] || [];
             const metadata = appNode['meta-data'];
@@ -31,18 +28,13 @@ module.exports = function (context) {
                 item['$']?.['android:name'] === 'firebase_analytics_collection_enabled'
             );
 
-            console.log("ANALYTICS: after findIndex");
-
             if (index !== -1) {
-                console.log("ANALYTICS: entry exists, will check if it's true or false");
                 // entry exists, check if we should update it
                 if (metadata[index]['$']['android:value'] === 'true') {
                     metadata[index]['$']['android:value'] = 'false';
                     updated = true;
-                    console.log("ANALYTICS: entry existed as true, changed to false");
                 }
             } else {
-                console.log("ANALYTICS: entry didn't exist, will push new one")
                 // entry doesn't exist, add it
                 metadata.push({
                     '$': {
@@ -52,24 +44,18 @@ module.exports = function (context) {
                 });
                 updated = true;
             }
-
             if (updated) {
-                console.log("ANALYTICS: updated is true so we'll write");
                 const builder = new xml2js.Builder();
                 const xml = builder.buildObject(result);
                 fs.writeFileSync(manifestPath, xml);
             }
-            console.log("ANALYTICS: end of parseStringPromise");
             defer.resolve();
         })
         .catch((err) => {
-            console.log("ANALYTICS: entered catch block");
             throw new Error (`OUTSYSTEMS_PLUGIN_ERROR: Something went wrong while parsing the AndroidManifest.xml file. Please check the logs for more information.`);
         });
     } else {
-        console.log("ANALYTICS: entered else so will do nothing");
         defer.resolve();
     }
-
     return defer.promise;
 };

--- a/hooks/android/androidCopyPreferences.js
+++ b/hooks/android/androidCopyPreferences.js
@@ -17,6 +17,9 @@ module.exports = function (context) {
     if (collectionEnabled.toLowerCase() == 'false') {
         let parser = new xml2js.Parser();
         parser.parseStringPromise(fs.readFileSync(manifestPath, 'utf8')).then((result) => {
+
+            console.log("ANALYTICS: inside parseStringPromise");
+
             const appNode = result.manifest.application[0];
             appNode['meta-data'] = appNode['meta-data'] || [];
             const metadata = appNode['meta-data'];
@@ -28,13 +31,18 @@ module.exports = function (context) {
                 item['$']?.['android:name'] === 'firebase_analytics_collection_enabled'
             );
 
+            console.log("ANALYTICS: after findIndex");
+
             if (index !== -1) {
+                console.log("ANALYTICS: entry exists, will check if it's true or false");
                 // entry exists, check if we should update it
                 if (metadata[index]['$']['android:value'] === 'true') {
                     metadata[index]['$']['android:value'] = 'false';
                     updated = true;
+                    console.log("ANALYTICS: entry existed as true, changed to false");
                 }
             } else {
+                console.log("ANALYTICS: entry didn't exist, will push new one")
                 // entry doesn't exist, add it
                 metadata.push({
                     '$': {
@@ -46,15 +54,19 @@ module.exports = function (context) {
             }
 
             if (updated) {
+                console.log("ANALYTICS: updated is true so we'll write");
                 const builder = new xml2js.Builder();
                 const xml = builder.buildObject(result);
                 fs.writeFileSync(manifestPath, xml);
             }
+            console.log("ANALYTICS: end of parseStringPromise");
         })
         .catch((err) => {
+            console.log("ANALYTICS: entered catch block");
             throw new Error (`OUTSYSTEMS_PLUGIN_ERROR: Something went wrong while parsing the AndroidManifest.xml file. Please check the logs for more information.`);
         });
     } else {
+        console.log("ANALYTICS: entered else so will do nothing");
         defer.resolve();
     }
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

- Avoids duplicating `<meta-data>` entry for `firebase_analytics_collection_enabled` when running hook in MOCA builds.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->
References: https://outsystemsrd.atlassian.net/browse/RMET-4277

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

Tested with MOCA builds in Mobile ALM tenant.

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
