### PR TITLE
RMET-4309 Firebase Analytics - added fix on setConsent client action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The changes documented here do not include those from the original repository.
 
+### Unreleased
+
+### Fix
+- [Android] `setConsent` client action returning error (https://outsystemsrd.atlassian.net/browse/RMET-4309).
+
 ## 5.0.0-OS18
 
 ### Features

--- a/src/android/com/outsystems/firebase/analytics/FirebaseAnalyticsPlugin.java
+++ b/src/android/com/outsystems/firebase/analytics/FirebaseAnalyticsPlugin.java
@@ -160,12 +160,13 @@ public class FirebaseAnalyticsPlugin extends CordovaPlugin {
 
             for (int i = 0; i < consentSettings.length(); i++) {
                 JSONObject consentItem = consentSettings.getJSONObject(i);
-                int typeValue = consentItem.getInt("Type");
-                int statusValue = consentItem.getInt("Status");
 
                 if (!consentItem.has("Type") || !consentItem.has("Status")) {
                     throw OSFANLError.Companion.invalidType("JSON passed Consent Type or Status", "Integer");
                 }
+
+                int typeValue = consentItem.getInt("Type");
+                int statusValue = consentItem.getInt("Status");
 
                 FirebaseAnalytics.ConsentType consentType = ConsentType.fromInt(typeValue);
                 FirebaseAnalytics.ConsentStatus consentStatus = ConsentStatus.fromInt(statusValue);

--- a/src/android/com/outsystems/firebase/analytics/FirebaseAnalyticsPlugin.java
+++ b/src/android/com/outsystems/firebase/analytics/FirebaseAnalyticsPlugin.java
@@ -163,6 +163,10 @@ public class FirebaseAnalyticsPlugin extends CordovaPlugin {
                 int typeValue = consentItem.getInt("Type");
                 int statusValue = consentItem.getInt("Status");
 
+                if (!consentItem.has("Type") || !consentItem.has("Status")) {
+                    throw OSFANLError.Companion.invalidType("JSON passed Consent Type or Status", "Integer");
+                }
+
                 FirebaseAnalytics.ConsentType consentType = ConsentType.fromInt(typeValue);
                 FirebaseAnalytics.ConsentStatus consentStatus = ConsentStatus.fromInt(statusValue);
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Added a fix to the `setConsent` client action due to missing validation when accessing object values from the passed consent settings list.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->
References: https://outsystemsrd.atlassian.net/browse/RMET-4309

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->
- Tested locally with Firebase Sample App in Android Studio using the simulator.

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
