### PR TITLE
chore(android,ios): remove unnecessary Firebase preferences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The changes documented here do not include those from the original repository.
 
+## 5.0.0-OS20
+
+### Chores
+- [Android,iOS] remove unnecessary Firebase preferences (https://outsystemsrd.atlassian.net/browse/RMET-4915).
+
 ## 5.0.0-OS19
 
 ### Fixes

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -25,7 +25,6 @@
 
 ## Checklist
 <!--- Go over all the following items and put an `x` in all the boxes that apply -->
-- [ ] Pull request title follows the format `RNMT-XXXX <title>`
 - [ ] Code follows code style of this project
 - [ ] CHANGELOG.md file is correctly updated
 - [ ] Changes require an update to the documentation

--- a/build-actions/setAnalyticsConfigurations.yaml
+++ b/build-actions/setAnalyticsConfigurations.yaml
@@ -14,16 +14,11 @@ platforms:
       - file: AndroidManifest.xml
         target: manifest/application
         inject: |
-          <meta-data android:name="google_analytics_automatic_screen_reporting_enabled" android:value="true"/>
-      - file: AndroidManifest.xml
-        target: manifest/application
-        inject: |
           <meta-data android:name="firebase_analytics_collection_enabled" android:value="$ANALYTICS_COLLECTION_ENABLED" />
   ios:
     plist:
       - replace: true
         entries:
-          - FirebaseAutomaticScreenReportingEnabled: true
           - FIREBASE_ANALYTICS_COLLECTION_ENABLED: $ANALYTICS_COLLECTION_ENABLED
             
       - replace: true

--- a/hooks/ios/iOSCopyPreferences.js
+++ b/hooks/ios/iOSCopyPreferences.js
@@ -29,9 +29,6 @@ module.exports = function (context) {
     if (collectionEnabled.toLowerCase() == 'false') {
         obj['FIREBASE_ANALYTICS_COLLECTION_ENABLED'] = false;
     }
-    
-    // always set FirebaseAutomaticScreenReportingEnabled it to true
-    obj['FirebaseAutomaticScreenReportingEnabled'] = true;
 
     fs.writeFileSync(infoPlistPath, plist.build(obj));
 };

--- a/hooks/ios/iOSCopyPreferences.js
+++ b/hooks/ios/iOSCopyPreferences.js
@@ -12,6 +12,8 @@ module.exports = function (context) {
     let infoPlistPath = path.join(projectRoot, 'platforms/ios/' + appName + '/'+ appName +'-info.plist');
     let obj = plist.parse(fs.readFileSync(infoPlistPath, 'utf8'));
 
+
+    // set NSUserTrackingUsageDescription if EnableAppTrackingTransparencyPrompt is true
     let enableAppTracking = configParser.getPlatformPreference("EnableAppTrackingTransparencyPrompt", "ios");
     if(enableAppTracking == "true" || enableAppTracking == ""){
         let userTrackingDescription = configParser.getPlatformPreference("USER_TRACKING_DESCRIPTION_IOS", "ios");
@@ -20,13 +22,16 @@ module.exports = function (context) {
         }
     }
     else if(enableAppTracking == "false"){
-        delete obj['NSUserTrackingUsageDescription'];        
+        delete obj['NSUserTrackingUsageDescription'];
     }
 
     let collectionEnabled = configParser.getGlobalPreference("ANALYTICS_COLLECTION_ENABLED");
     if (collectionEnabled.toLowerCase() == 'false') {
         obj['FIREBASE_ANALYTICS_COLLECTION_ENABLED'] = false;
-    } 
+    }
+    
+    // always set FirebaseAutomaticScreenReportingEnabled it to true
+    obj['FirebaseAutomaticScreenReportingEnabled'] = true;
 
     fs.writeFileSync(infoPlistPath, plist.build(obj));
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-firebase-analytics",
-  "version": "5.0.0-OS19",
+  "version": "5.0.0-OS20",
   "description": "Cordova plugin for Firebase Analytics",
   "cordova": {
     "id": "cordova-plugin-firebase-analytics",

--- a/plugin.xml
+++ b/plugin.xml
@@ -41,9 +41,6 @@ xmlns:android="http://schemas.android.com/apk/res/android"
             use a bit hacky method to set boolean value as a string:
             https://developer.apple.com/documentation/foundation/nsstring/1409420-boolvalue?preferredLanguage=occ
         -->
-        <config-file target="*-Info.plist" parent="FirebaseAutomaticScreenReportingEnabled">
-            <string>$AUTOMATIC_SCREEN_REPORTING_ENABLED</string>
-        </config-file>
         <config-file target="*-Info.plist" parent="NSUserTrackingUsageDescription">
             <string>$USER_TRACKING_DESCRIPTION_IOS</string>
         </config-file>

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
 xmlns:android="http://schemas.android.com/apk/res/android"
            id="cordova-plugin-firebase-analytics"
-      version="5.0.0-OS19">
+      version="5.0.0-OS20">
 
     <name>FirebaseAnalyticsPlugin</name>
     <description>Cordova plugin for Firebase Analytics</description>

--- a/plugin.xml
+++ b/plugin.xml
@@ -20,7 +20,6 @@ xmlns:android="http://schemas.android.com/apk/res/android"
         <engine name="cordova-ios" version=">=5.1.1"/>
     </engines>
 
-    <preference name="AUTOMATIC_SCREEN_REPORTING_ENABLED" default="true" />
     <preference name="USER_TRACKING_DESCRIPTION_IOS" default="$(PRODUCT_NAME) needs your attention." />
 
     <platform name="ios">
@@ -90,10 +89,6 @@ xmlns:android="http://schemas.android.com/apk/res/android"
 
         <edit-config target="AndroidManifest.xml" parent="/*">
             <uses-permission android:name="android.permission.INTERNET" />
-        </edit-config>
-
-        <edit-config target="AndroidManifest.xml" parent="/manifest/application">
-            <meta-data android:name="google_analytics_automatic_screen_reporting_enabled" android:value="$AUTOMATIC_SCREEN_REPORTING_ENABLED" />
         </edit-config>
 
         <framework src="build.gradle" custom="true" type="gradleReference" />


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

- This PR removes the following Firebase preferences:
    - `google_analytics_automatic_screen_reporting_enabled` on Android
    - `FirebaseAutomaticScreenReportingEnabled` on iOS

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->
- We were always setting these to `true`, which is unnecessary, because they're already `true` by default.
- Also, on iOS, we were setting it as a `string` in the `.plist` file instead of a `boolean`, which was wrong. It probably didn't have an effect because it was already `true` by default.

References: https://outsystemsrd.atlassian.net/browse/RMET-4915

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [x] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

Tested in O11 and ODC with our Firebase Sample App.

MABS builds:

- [Android](https://intranet.outsystems.net/MABS_Lite/BuildDetail?id=4e512ce67b64e4b979fec17ed594d323390b7315&stg=dev)
- [iOS](https://intranet.outsystems.net/MABS_Lite/BuildDetail?id=16264775c84f56d2cc618fc200897b3115804959&stg=dev)

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
