### PR TITLE
fix(android): use cdvPluginPostBuildExtras instead of ext.postBuildExtras

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The changes documented here do not include those from the original repository.
 
+## 5.0.0-OS22
+
+### Fixes
+- [Android] Avoid overwriting other plugins' `ext.postBuildExtras` Gradle configuration (https://outsystemsrd.atlassian.net/browse/RMET-5211).
+
 ## 5.0.0-OS21
 
 ### Features

--- a/build.gradle
+++ b/build.gradle
@@ -6,24 +6,10 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:3.6.4'
-        classpath 'com.google.gms:google-services:4.3.14'
     }
 }
 
 dependencies {
     implementation platform('com.google.firebase:firebase-bom:33.2.0')
     implementation("com.google.firebase:firebase-analytics")
-}
-
-// use postBuildExtras to make sure the plugin is applied after
-// cdvPluginPostBuildExtras. Therefore if googleServices is added
-// to cdvPluginPostBuildExtras somewhere else, the plugin execution
-// will be skipped and project build will be successfull
-ext.postBuildExtras = {
-    if (project.extensions.findByName('googleServices') == null) {
-        // apply plugin: 'com.google.gms.google-services'
-        // class must be used instead of id(string) to be able to apply plugin from non-root gradle file
-        apply plugin: com.google.gms.googleservices.GoogleServicesPlugin
-        googleServices.disableVersionCheck = true
-    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -6,10 +6,18 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:3.6.4'
+        classpath 'com.google.gms:google-services:4.3.14'
     }
 }
 
 dependencies {
     implementation platform('com.google.firebase:firebase-bom:33.2.0')
     implementation("com.google.firebase:firebase-analytics")
+}
+
+cdvPluginPostBuildExtras.add {
+    if (project.extensions.findByName('googleServices') == null) {
+        apply plugin: com.google.gms.googleservices.GoogleServicesPlugin
+        googleServices.disableVersionCheck = true
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,8 @@ dependencies {
 }
 
 cdvPluginPostBuildExtras.add {
-    apply plugin: com.google.gms.googleservices.GoogleServicesPlugin
-    googleServices.disableVersionCheck = true
+    if (project.extensions.findByName('googleServices') == null) {
+        apply plugin: com.google.gms.googleservices.GoogleServicesPlugin
+        googleServices.disableVersionCheck = true
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ dependencies {
 }
 
 cdvPluginPostBuildExtras.add {
-    if (project.extensions.findByName('googleServices') == null) {
+    if (plugins.hasPlugin('com.android.application') && project.extensions.findByName('googleServices') == null) {
         apply plugin: com.google.gms.googleservices.GoogleServicesPlugin
         googleServices.disableVersionCheck = true
     }

--- a/build.gradle
+++ b/build.gradle
@@ -16,8 +16,6 @@ dependencies {
 }
 
 cdvPluginPostBuildExtras.add {
-    if (project.extensions.findByName('googleServices') == null) {
-        apply plugin: com.google.gms.googleservices.GoogleServicesPlugin
-        googleServices.disableVersionCheck = true
-    }
+    apply plugin: com.google.gms.googleservices.GoogleServicesPlugin
+    googleServices.disableVersionCheck = true
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-firebase-analytics",
-  "version": "5.0.0-OS21",
+  "version": "5.0.0-OS22",
   "description": "Cordova plugin for Firebase Analytics",
   "cordova": {
     "id": "cordova-plugin-firebase-analytics",

--- a/plugin.xml
+++ b/plugin.xml
@@ -85,6 +85,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
                 <param name="android-package" value="com.outsystems.plugins.firebase.analytics.FirebaseAnalyticsPlugin" />
                 <param name="onload" value="true" />
             </feature>
+            <preference name="GradlePluginGoogleServicesEnabled" value="true" />
         </config-file>
 
         <edit-config target="AndroidManifest.xml" parent="/*">

--- a/plugin.xml
+++ b/plugin.xml
@@ -85,7 +85,6 @@ xmlns:android="http://schemas.android.com/apk/res/android"
                 <param name="android-package" value="com.outsystems.plugins.firebase.analytics.FirebaseAnalyticsPlugin" />
                 <param name="onload" value="true" />
             </feature>
-            <preference name="GradlePluginGoogleServicesEnabled" value="true" />
         </config-file>
 
         <edit-config target="AndroidManifest.xml" parent="/*">

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
 xmlns:android="http://schemas.android.com/apk/res/android"
            id="cordova-plugin-firebase-analytics"
-      version="5.0.0-OS21">
+      version="5.0.0-OS22">
 
     <name>FirebaseAnalyticsPlugin</name>
     <description>Cordova plugin for Firebase Analytics</description>


### PR DESCRIPTION
**Problem**
When more than one Cordova plugin sets `ext.postBuildExtras` in its `build.gradle`, the last plugin loaded silently overwrites whatever the previous one set. The earlier plugin's config disappears from the build.

A customer hit this with our Firebase Analytics plugin and a third party plugin they were using. Both were setting `ext.postBuildExtras`. Firebase Analytics happened to load last and clobbered the third party plugin's Java 11 compile options, which silently dropped from their build.

**Solution**
`cordova-android` also exposes [a list](https://issues.apache.org/jira/browse/CB-14163) called `cdvPluginPostBuildExtras` that plugins are supposed to append to with `.add { ... }`. The framework runs every entry in the list at the end of the build, so multiple plugins can each contribute without stepping on each other. This has been around since `cordova-android` `6.x`, but our plugins were still using the older single property version. Capacitor builds iterate the same list, so the fix works in both environments.

The same change was applied across the other affected Firebase plugins (Cloud Messaging, Crashlytics, Performance) and Auth Connect, which had an empty `ext.postBuildExtras = {}` that was actively wiping out other plugins' configs for no reason.

**Other Considerations**
We also looked at whether the whole block could just be deleted. The [original commit ](https://github.com/OutSystems/cordova-plugin-firebase-analytics/commit/6f4ec3688e2d0e66582ac0b79c55fb9368a89f77)from 5 years ago noted this was a MABS 6 workaround and that a preference in `plugin.xml` would replace it in MABS 7. That preference does exist now (`GradlePluginGoogleServicesEnabled`) and it works in isolation, but from my testing, MABS 12's app scaffold hardcodes that preference to `false` in the generated `config.xml`, and `cordova-android` picks the first value it sees. Our plugin's value gets ignored. The check inside it (`findByName('googleServices') == null`) makes it a no-op if something else already applied `google-services`, so it's safe to keep.