### PR TITLE
chore(android): Add missing kotlin declaration in plugin.xml

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -60,6 +60,8 @@
                                             <param name="android-package" value="com.outsystems.plugins.firebase.analytics.FirebaseAnalyticsPlugin"/>
                                             <param name="onload" value="true"/>
                                  </feature>
+                                 <preference name="GradlePluginKotlinEnabled" value="true"/>
+                                 <preference name="GradlePluginKotlinCodeStyle" value="official"/>
                       </config-file>
                       <edit-config target="AndroidManifest.xml" parent="/*">
                                  <uses-permission android:name="android.permission.INTERNET"/>


### PR DESCRIPTION
This PR adds kotlin preference to `plugin.xml`.

For OutSystems apps this doesn't really fix anything because those always have kotlin enabled by default. So we don't need to release a new version of an OutSystems Plugin because of this.

It's really more just for consistency sake.

Internal JIRA Ref: https://outsystemsrd.atlassian.net/browse/RMET-5359